### PR TITLE
Fix docs: replace template placeholders with actual project content

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,4 @@
 [![Commit activity](https://img.shields.io/github/commit-activity/m/samuelduchesne/idfkit)](https://img.shields.io/github/commit-activity/m/samuelduchesne/idfkit)
 [![License](https://img.shields.io/github/license/samuelduchesne/idfkit)](https://img.shields.io/github/license/samuelduchesne/idfkit)
 
-This is a template repository for Python projects that use uv for their dependency management.
+A fast, modern EnergyPlus IDF/epJSON parser for Python with O(1) lookups and reference tracking.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,1 +1,3 @@
-::: idfkit.foo
+# API Reference
+
+::: idfkit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: idfkit
 repo_url: https://github.com/samuelduchesne/idfkit
 site_url: https://samuelduchesne.github.io/idfkit
-site_description: This is a template repository for Python projects that use uv for their dependency management.
+site_description: A fast, modern EnergyPlus IDF/epJSON parser for Python with O(1) lookups and reference tracking.
 site_author: Samuel Letellier-Duchesne
 edit_uri: edit/main/docs/
 repo_name: samuelduchesne/idfkit
@@ -9,13 +9,13 @@ copyright: Maintained by <a href="https://samuelduchesne.com">samuelduchesne</a>
 
 nav:
   - Home: index.md
-  - Modules: modules.md
+  - API Reference: modules.md
 plugins:
   - search
   - mkdocstrings:
       handlers:
         python:
-          paths: ["src/idfkit"]
+          paths: ["src"]
 theme:
   name: material
   features:


### PR DESCRIPTION
- Replace idfkit.foo reference in modules.md with actual idfkit module
- Update site description from template placeholder to project description
- Fix mkdocstrings paths from src/idfkit to src for correct module resolution
- Rename nav entry from Modules to API Reference

https://claude.ai/code/session_01PPzHzUYzyQPPPVdmb3dG7E