### PR TITLE
Fix pyright reportMissingImports error for optional pandas import

### DIFF
--- a/src/idfkit/schedules/series.py
+++ b/src/idfkit/schedules/series.py
@@ -52,7 +52,7 @@ def to_series(
         ImportError: If pandas is not installed.
     """
     try:
-        import pandas  # pyright: ignore[reportMissingTypeStubs]
+        import pandas  # pyright: ignore[reportMissingImports, reportMissingTypeStubs]
     except ImportError:
         msg = "pandas is required for to_series(). Install with: pip install idfkit[dataframes]"
         raise ImportError(msg) from None


### PR DESCRIPTION
The pyright ignore comment only suppressed reportMissingTypeStubs but
pandas is an optional dependency not installed in the dev environment,
causing a reportMissingImports error during make check.

https://claude.ai/code/session_01JQzTgsRsPoSL7ED9B5c2yf