### PR TITLE
Fix dark mode theme tests to match new auto default

### DIFF
--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -359,12 +359,12 @@ class TestThemeSupport:
         doc.add("Construction", "Wall", {"outside_layer": "Concrete"})
         return doc["Construction"]["Wall"]
 
-    def test_default_theme_is_light(self) -> None:
-        assert SVGConfig().theme == "light"
+    def test_default_theme_is_auto(self) -> None:
+        assert SVGConfig().theme == "auto"
 
-    def test_light_theme_svg_class(self, opaque_construction: IDFObject) -> None:
+    def test_default_theme_svg_class(self, opaque_construction: IDFObject) -> None:
         svg = construction_to_svg(opaque_construction)
-        assert 'class="idfkit-theme-light"' in svg
+        assert 'class="idfkit-theme-auto"' in svg
 
     def test_light_theme_css_variables(self, opaque_construction: IDFObject) -> None:
         svg = construction_to_svg(opaque_construction)


### PR DESCRIPTION
The SVGConfig default theme was changed from "light" to "auto" in
commit 9c2b801, but two tests still expected the old default. Update
test_default_theme_is_light → test_default_theme_is_auto and
test_light_theme_svg_class → test_default_theme_svg_class to match.

https://claude.ai/code/session_01XYK2mVrM6pyN6NQw7BaSbp