### PR TITLE
Fix 5 bugs in the caching layer

### DIFF
--- a/src/idfkit/simulation/async_runner.py
+++ b/src/idfkit/simulation/async_runner.py
@@ -140,6 +140,7 @@ async def async_simulate(
                 annual=annual,
                 design_day=design_day,
                 output_suffix=output_suffix,
+                readvars=readvars,
                 extra_args=extra_args,
             )
             cached = cache.get(cache_key)

--- a/src/idfkit/simulation/runner.py
+++ b/src/idfkit/simulation/runner.py
@@ -133,6 +133,7 @@ def simulate(
                 annual=annual,
                 design_day=design_day,
                 output_suffix=output_suffix,
+                readvars=readvars,
                 extra_args=extra_args,
             )
             cached = cache.get(cache_key)

--- a/tests/schedules/test_compact.py
+++ b/tests/schedules/test_compact.py
@@ -339,6 +339,7 @@ class TestParseCompactCaching:
         """Test that calling parse_compact twice returns cached result."""
         obj = MagicMock()
         obj.obj_type = "Schedule:Compact"
+        obj.mutation_version = 0
 
         fields = {
             "Field 1": "Through: 12/31",


### PR DESCRIPTION
1. ScheduleFileCache key collision: cache key was only the file path,
   so two Schedule:File objects pointing at the same CSV with different
   Column Number / Rows to Skip / Separator would return wrong data.
   Key now includes all parsing parameters.

2. WeatherDownloader perpetual re-extraction: _is_stale() used st_mtime
   on extracted files, but zipfile.extractall preserves archive-internal
   timestamps, making freshly extracted EPW files always appear stale.
   Now compares EPW mtime against the ZIP mtime instead.

3. SimulationCache key missing readvars: the readvars flag was not part
   of compute_key(), so a cache hit from readvars=False would be served
   to a readvars=True request, silently missing CSV output files.

4. Schedule:Compact parse cache stale after mutation: the WeakKeyDictionary
   cache had no invalidation when IDFObject fields changed. Added a
   mutation_version counter to IDFObject that is checked on cache lookup.

5. SimulationCache.get() crash on corrupted metadata: malformed JSON or
   missing keys in _cache_meta.json raised exceptions instead of returning
   None (cache miss). Now catches JSONDecodeError/KeyError/OSError.

https://claude.ai/code/session_01GZYxaqQ6xXF6jDYMeZhsZm