### PR TITLE
Fix 5 bugs in parser, schema, and writer modules

### DIFF
--- a/src/idfkit/idf_parser.py
+++ b/src/idfkit/idf_parser.py
@@ -326,8 +326,8 @@ class IDFParser:
                 # Handle scientific notation
                 return float(value)
             except ValueError:
-                # Might be "autocalculate", "autosize", etc.
-                return value.lower()
+                # Might be "Autocalculate", "Autosize", etc. — preserve original casing
+                return value
 
         elif field_type == "integer":
             try:
@@ -355,6 +355,9 @@ def iter_idf_objects(
 
     with open(filepath, "rb") as f:
         content = f.read()
+
+    # Strip comments before matching to prevent phantom objects
+    content = _COMMENT_PATTERN.sub(b"", content)
 
     for match in _OBJECT_PATTERN.finditer(content):
         obj_type = match.group(1).decode(encoding).strip()

--- a/src/idfkit/schema.py
+++ b/src/idfkit/schema.py
@@ -118,7 +118,7 @@ class EpJSONSchema:
         if not obj_schema:
             return []
         legacy = obj_schema.get("legacy_idd", {})
-        return legacy.get("fields", [])
+        return list(legacy.get("fields", []))
 
     def get_required_fields(self, obj_type: str) -> list[str]:
         """Get list of required field names for an object type."""

--- a/src/idfkit/writers.py
+++ b/src/idfkit/writers.py
@@ -238,9 +238,16 @@ class EpJSONWriter:
                 continue
 
             result[obj_type] = {}
+            nameless_counter = 0
             for obj in collection:
                 obj_data = self._object_to_dict(obj)
-                result[obj_type][obj.name] = obj_data
+                if obj.name:
+                    key = obj.name
+                else:
+                    # Generate unique key for nameless objects (e.g. Output:Variable)
+                    nameless_counter += 1
+                    key = f"{obj_type} {nameless_counter}"
+                result[obj_type][key] = obj_data
 
         return result
 
@@ -249,7 +256,7 @@ class EpJSONWriter:
         result: dict[str, Any] = {}
 
         for field_name, value in obj.data.items():
-            if value is not None:
+            if value is not None and value != "":
                 result[field_name] = self._format_value(value)
 
         return result


### PR DESCRIPTION
- iter_idf_objects: strip comments before regex matching to prevent
  phantom objects from comment text (e.g. "!- X,Y,Z" matching as "X,")
- EpJSONWriter: generate unique keys for nameless objects so duplicates
  like multiple Output:Variable are preserved instead of overwritten
- get_all_field_names: return a copy of the schema list to prevent
  extensible field parsing from permanently mutating the schema
- _coerce_value: preserve original casing for non-numeric values in
  number fields (Autosize was lowercased to autosize)
- EpJSONWriter: omit empty string values from epJSON output

https://claude.ai/code/session_012mCdetjfVEWtKM8TuSVCDv