### PR TITLE
Fix documentation inconsistencies with actual codebase

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -88,6 +88,22 @@ Visualize simulation results with matplotlib or plotly:
     uv add idfkit[plotly]
     ```
 
+### Progress Bars
+
+Show tqdm progress bars during batch simulations:
+
+=== "pip"
+
+    ```bash
+    pip install idfkit[progress]
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add idfkit[progress]
+    ```
+
 ### Cloud Storage (S3)
 
 Store simulation results in Amazon S3:

--- a/docs/troubleshooting/errors.md
+++ b/docs/troubleshooting/errors.md
@@ -128,6 +128,7 @@ Common extras:
 | DataFrames | `pip install idfkit[dataframes]` |
 | Plotting (matplotlib) | `pip install idfkit[plot]` |
 | Plotting (plotly) | `pip install idfkit[plotly]` |
+| Progress bars (tqdm) | `pip install idfkit[progress]` |
 | S3 Storage | `pip install idfkit[s3]` |
 | Weather refresh | `pip install idfkit[weather]` |
 

--- a/docs/weather/design-days.md
+++ b/docs/weather/design-days.md
@@ -28,16 +28,12 @@ print(f"Added {len(added)} design days")
 Use `apply_ashrae_sizing()` for a streamlined workflow:
 
 ```python
-from idfkit.weather import apply_ashrae_sizing, WeatherDownloader
+from idfkit.weather import apply_ashrae_sizing
 
-# Download DDY file
-downloader = WeatherDownloader()
-files = downloader.download(station)
-
-# Apply standard design conditions
+# Apply standard design conditions (downloads DDY from station automatically)
 added = apply_ashrae_sizing(
     model,
-    ddy_path=files.ddy,
+    station,
     standard="90.1",  # ASHRAE 90.1 criteria
 )
 ```
@@ -72,8 +68,8 @@ DDY files contain multiple design day types classified by ASHRAE criteria:
 |------|-------------|
 | `DEHUMID_0_4` | 0.4% dehumidification |
 | `DEHUMID_1` | 1% dehumidification |
-| `HUMIDIF_99_6` | 99.6% humidification |
-| `MONTHLY` | Monthly design conditions |
+| `HUMIDIFICATION_99_6` | 99.6% humidification |
+| `HUMIDIFICATION_99` | 99% humidification |
 
 ## Accessing Design Days
 
@@ -97,9 +93,9 @@ if clg:
 ### All Design Days
 
 ```python
-# All classified annual design days
-for dd_type, dd_obj in ddm.annual.items():
-    print(f"{dd_type.name}: {dd_obj.name}")
+# All classified annual design days (returns a list of IDFObject)
+for dd_obj in ddm.annual:
+    print(dd_obj.name)
 
 # Monthly design days
 for dd_obj in ddm.monthly:
@@ -129,14 +125,17 @@ added = ddm.apply_to_model(
 )
 ```
 
-### Update Site Location
+### Skip Site Location Update
+
+By default, `apply_to_model` also updates the `Site:Location` object.
+To skip this, set `update_location=False`:
 
 ```python
 added = ddm.apply_to_model(
     model,
     heating="99.6%",
     cooling="1%",
-    update_location=True,  # Also add/update Site:Location
+    update_location=False,  # Keep existing Site:Location
 )
 ```
 
@@ -153,8 +152,8 @@ added = ddm.apply_to_model(
     cooling="1%",
 )
 
-# Or use the convenience function
-added = apply_ashrae_sizing(model, ddy_path=files.ddy, standard="90.1")
+# Or use the convenience function (takes a WeatherStation, not a path)
+added = apply_ashrae_sizing(model, station, standard="90.1")
 ```
 
 ### ASHRAE 62.1 (Ventilation)

--- a/docs/weather/downloads.md
+++ b/docs/weather/downloads.md
@@ -27,7 +27,10 @@ The `download()` method returns a `WeatherFiles` object:
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `epw` | `Path` | Path to the EPW file |
-| `ddy` | `Path \| None` | Path to the DDY file (may be None) |
+| `ddy` | `Path` | Path to the DDY file |
+| `stat` | `Path \| None` | Path to the STAT file (may be None) |
+| `zip_path` | `Path` | Path to the original downloaded ZIP archive |
+| `station` | `WeatherStation` | The station this download corresponds to |
 
 ```python
 files = downloader.download(station)
@@ -37,9 +40,8 @@ from idfkit.simulation import simulate
 result = simulate(model, files.epw)
 
 # Use for design days
-if files.ddy:
-    from idfkit.weather import DesignDayManager
-    ddm = DesignDayManager(files.ddy)
+from idfkit.weather import DesignDayManager
+ddm = DesignDayManager(files.ddy)
 ```
 
 ## Caching
@@ -187,9 +189,8 @@ downloader = WeatherDownloader()
 files = downloader.download(station)
 
 # Apply design days
-if files.ddy:
-    ddm = DesignDayManager(files.ddy)
-    ddm.apply_to_model(model, heating="99.6%", cooling="1%")
+ddm = DesignDayManager(files.ddy)
+ddm.apply_to_model(model, heating="99.6%", cooling="1%")
 
 # Run simulation
 result = simulate(model, files.epw, design_day=True)

--- a/docs/weather/station-search.md
+++ b/docs/weather/station-search.md
@@ -69,7 +69,10 @@ def nearest(
     self,
     latitude: float,
     longitude: float,
-    limit: int = 10,
+    *,
+    limit: int = 5,
+    max_distance_km: float | None = None,
+    country: str | None = None,
 ) -> list[SpatialResult]:
 ```
 
@@ -110,13 +113,14 @@ california = [s for s in us_stations if s.state == "CA"]
 
 ## Filter by Coordinates
 
+Use `nearest()` with `max_distance_km` to find stations within a geographic area:
+
 ```python
-# Bounding box filter
-stations = index.filter(
-    lat_min=40.0,
-    lat_max=42.0,
-    lon_min=-90.0,
-    lon_max=-87.0,
+# Find all stations within 100 km of a point
+stations = index.nearest(
+    41.0, -88.5,
+    max_distance_km=100.0,
+    limit=50,
 )
 ```
 
@@ -127,7 +131,7 @@ stations = index.filter(
 results = index.get_by_wmo("725300")
 
 for station in results:
-    print(f"{station.display_name}: {station.source_data}")
+    print(f"{station.display_name}: {station.source}")
 ```
 
 Note: WMO numbers are **not unique** — multiple entries can share a WMO
@@ -141,10 +145,10 @@ Note: WMO numbers are **not unique** — multiple entries can share a WMO
 | `state` | `str` | State/province/region |
 | `country` | `str` | Country name |
 | `wmo` | `str` | WMO station number |
-| `source_data` | `str` | Data source (e.g., "TMYx.2009-2023") |
+| `source` | `str` | Data source identifier (e.g., "SRC-TMYx") |
 | `latitude` | `float` | Station latitude |
 | `longitude` | `float` | Station longitude |
-| `time_zone` | `float` | UTC offset |
+| `timezone` | `float` | UTC offset (hours from GMT) |
 | `elevation` | `float` | Elevation in meters |
 | `url` | `str` | Download URL for weather files |
 | `display_name` | `str` | Formatted name (city, state, country) |

--- a/src/idfkit/simulation/__init__.py
+++ b/src/idfkit/simulation/__init__.py
@@ -21,14 +21,14 @@ The module provides parsers for the most commonly used EnergyPlus output formats
   This is the recommended output format as it contains all simulation data in a
   single queryable file.
 - **CSV** (:class:`CSVResult`): Time-series data in comma-separated format.
+- **HTML** (:class:`HTMLResult`): Tabular reports in HTML format.
 - **RDD/MDD** (:class:`OutputVariableIndex`): Available output variables and meters.
 - **ERR** (:class:`ErrorReport`): Errors, warnings, and simulation status.
 
-The following parsers are **intentionally not implemented** as the SQLite output
+The following formats are **intentionally not implemented** as the SQLite output
 covers the same data more reliably and completely:
 
 - **ESO/MTR**: Binary-text time-series format (use SQLite instead).
-- **HTML**: Tabular reports in HTML format (use SQLite's tabular data instead).
 - **EIO**: Simulation metadata and invariant outputs (use SQLite instead).
 
 If you have a specific need for these formats, please open an issue describing


### PR DESCRIPTION
- station-search.md: Fix attribute names (source_data→source,
  time_zone→timezone), correct nearest() signature (limit default is 5,
  add missing keyword-only params), replace non-existent filter() bounding
  box parameters with nearest(max_distance_km=...) example
- design-days.md: Fix apply_ashrae_sizing() signature (takes station, not
  ddy_path), fix ddm.annual usage (returns list, not dict), fix enum name
  (HUMIDIF_99_6→HUMIDIFICATION_99_6), document update_location defaults
  to True
- downloads.md: Fix WeatherFiles.ddy type (Path, not Path|None), add
  missing attributes (stat, zip_path, station), remove unnecessary None
  guards
- installation.md: Add missing progress extra (tqdm) section
- troubleshooting/errors.md: Add progress extra to install table
- simulation/__init__.py: Update docstring to reflect that HTML parser is
  implemented

https://claude.ai/code/session_01VGJM9qvapweYTNx2G9gHYE