### PR TITLE
Fix CI cache ineffectiveness: disable aggressive pruning, fix Python version handling

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -23,8 +23,9 @@ runs:
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: 'true'
-        cache-suffix: ${{ matrix.python-version }}
+        cache-suffix: ${{ inputs.python-version }}
+        prune-cache: false
 
     - name: Install Python dependencies
-      run: uv sync --frozen
+      run: uv sync --frozen --python ${{ inputs.python-version }}
       shell: bash


### PR DESCRIPTION
Three issues caused the uv cache to show 0MB and re-download all packages:

1. prune-cache defaulted to true in setup-uv@v7, which runs
   `uv cache prune --ci` and strips the cache to ~75KB before saving
2. cache-suffix referenced matrix.python-version (empty for non-matrix
   jobs) instead of inputs.python-version
3. uv sync ignored setup-python and used system Python 3.12 (from
   .python-version file) instead of the requested matrix version

https://claude.ai/code/session_015AYh8wX6Xn6jE4qtito3mg