### PR TITLE
Remove redundant document=doc from schedule docs snippets

### DIFF
--- a/docs/snippets/schedules/index/design_day_evaluation.py
+++ b/docs/snippets/schedules/index/design_day_evaluation.py
@@ -12,7 +12,6 @@ from idfkit.schedules import evaluate
 value = evaluate(
     schedule,
     datetime(2024, 7, 15, 14, 0),
-    document=doc,
     day_type="summer",
 )
 
@@ -20,7 +19,6 @@ value = evaluate(
 value = evaluate(
     schedule,
     datetime(2024, 1, 15, 6, 0),
-    document=doc,
     day_type="winter",
 )
 # --8<-- [end:example]

--- a/docs/snippets/schedules/index/example_analyze_office_occupancy.py
+++ b/docs/snippets/schedules/index/example_analyze_office_occupancy.py
@@ -12,14 +12,14 @@ doc = load_idf("office.idf")
 occupancy = doc["Schedule:Compact"]["BLDG_OCC_SCH"]
 
 # Get annual values
-annual = values(occupancy, year=2024, document=doc)
+annual = values(occupancy, year=2024)
 
 # Basic statistics
 total_hours = len([v for v in annual if v > 0])
 print(f"Occupied hours: {total_hours}")
 
 # Peak analysis with pandas
-series = to_series(occupancy, year=2024, document=doc)
+series = to_series(occupancy, year=2024)
 print(f"Peak occupancy: {series.max()}")
 print(f"Average (occupied): {series[series > 0].mean():.2f}")
 

--- a/docs/snippets/schedules/index/holiday_support.py
+++ b/docs/snippets/schedules/index/holiday_support.py
@@ -14,5 +14,5 @@ print(f"Holidays: {holidays}")
 
 # Evaluation automatically uses holiday schedules on those dates
 christmas = datetime(2024, 12, 25, 10, 0)
-value = evaluate(schedule, christmas, document=doc)
+value = evaluate(schedule, christmas)
 # --8<-- [end:example]

--- a/docs/snippets/schedules/index/pandas_integration.py
+++ b/docs/snippets/schedules/index/pandas_integration.py
@@ -8,9 +8,9 @@ schedule: IDFObject = ...  # type: ignore[assignment]
 from idfkit.schedules import to_series, plot_schedule
 
 # Convert to pandas Series with datetime index
-series = to_series(schedule, year=2024, document=doc)
+series = to_series(schedule, year=2024)
 print(series.describe())
 
 # Quick visualization
-plot_schedule(schedule, year=2024, document=doc)
+plot_schedule(schedule, year=2024)
 # --8<-- [end:example]

--- a/docs/snippets/schedules/index/quick_start.py
+++ b/docs/snippets/schedules/index/quick_start.py
@@ -16,10 +16,10 @@ doc = load_idf("building.idf")
 schedule = doc["Schedule:Compact"]["Office Occupancy"]
 
 # Evaluate at a specific time
-value = evaluate(schedule, datetime(2024, 1, 8, 10, 0), document=doc)
+value = evaluate(schedule, datetime(2024, 1, 8, 10, 0))
 print(f"Value at Monday 10am: {value}")
 
 # Get hourly values for a full year
-hourly = values(schedule, year=2024, document=doc)
+hourly = values(schedule, year=2024)
 print(f"Annual hours: {len(hourly)}")  # 8784 for leap year
 # --8<-- [end:example]

--- a/docs/snippets/schedules/index/sub_hourly_timesteps.py
+++ b/docs/snippets/schedules/index/sub_hourly_timesteps.py
@@ -8,9 +8,9 @@ schedule: IDFObject = ...  # type: ignore[assignment]
 from idfkit.schedules import values
 
 # 15-minute intervals (4 per hour)
-quarter_hourly = values(schedule, year=2024, timestep=4, document=doc)
+quarter_hourly = values(schedule, year=2024, timestep=4)
 print(f"Values: {len(quarter_hourly)}")  # 35136 for leap year
 
 # 1-minute intervals
-minute_values = values(schedule, year=2024, timestep=60, document=doc)
+minute_values = values(schedule, year=2024, timestep=60)
 # --8<-- [end:example]


### PR DESCRIPTION
Schedule objects obtained from an IDFDocument already carry a
_document back-reference, so passing document= explicitly is
unnecessary and adds noise to the user-facing examples.

https://claude.ai/code/session_01YPjGduL7tVaLgdF9hpYLME