### PR TITLE
Fix badges not rendering by adding markdown attribute to div

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ A fast, modern EnergyPlus IDF/epJSON toolkit for Python — with O(1) lookups,
 automatic reference tracking, and built-in simulation support.
 </p>
 
-<div class="badges">
+<div class="badges" markdown>
 
 [![Release](https://img.shields.io/github/v/release/samuelduchesne/idfkit)](https://img.shields.io/github/v/release/samuelduchesne/idfkit)
 [![Build status](https://img.shields.io/github/actions/workflow/status/samuelduchesne/idfkit/main.yml?branch=main)](https://github.com/samuelduchesne/idfkit/actions/workflows/main.yml?query=branch%3Amain)


### PR DESCRIPTION
The <div class="badges"> element was missing the `markdown` attribute
required by the md_in_html extension to process Markdown content inside
HTML block elements.

https://claude.ai/code/session_01LZm8kLxVCHUHa9Rum8Vt1c