### PR TITLE
Add manual docs deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,20 @@
+name: deploy-docs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Deploy documentation
+        run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
Allow redeploying docs without creating a release by adding a
workflow_dispatch-triggered workflow.

https://claude.ai/code/session_01GZg8P7gPs8DmCu33UzMeLR