### PR TITLE
Fix hero buttons not rendering in docs index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ automatic reference tracking, and built-in simulation support.
 
 </div>
 
-<div class="hero-buttons">
+<div class="hero-buttons" markdown>
 
 [Get Started :material-arrow-right:](getting-started/installation.md){ .md-button .md-button--primary }
 [API Reference](api/document.md){ .md-button }


### PR DESCRIPTION
Add missing `markdown` attribute to the `hero-buttons` div so MkDocs
Material processes the button markdown syntax instead of showing raw text.

https://claude.ai/code/session_01JD4MPcmX8Ndz4F64qEizPe