### PR TITLE
Fix mobile hero centering by hiding edit/view action buttons on landing page

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -14,6 +14,11 @@
   --md-accent-fg-color: #ff9100;
 }
 
+/* ===== Hide edit/view actions on the landing page — they offset hero centering ===== */
+.md-content__inner:has(> .hero) > .md-content__button {
+  display: none;
+}
+
 /* ===== Hero section on landing page ===== */
 .md-typeset .hero {
   display: flex;


### PR DESCRIPTION
The Material for MkDocs content action buttons (view/edit on GitHub) float
right inside .md-content__inner, taking up flow space that shifts the
centered hero div to the left on narrow viewports. Hide them on the landing
page using :has() since they serve no purpose on a hero/landing page.

https://claude.ai/code/session_01L7xp1WwebrCjMTL2wdH2ei