### PR TITLE
Hide permalink icon on hero heading in docs landing page

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -40,6 +40,10 @@
   -webkit-text-fill-color: transparent;
 }
 
+.md-typeset .hero h1 .headerlink {
+  display: none;
+}
+
 [data-md-color-scheme="slate"] .md-typeset .hero h1 {
   background: linear-gradient(135deg, #ff6d00 0%, #ff9100 50%, #ffab40 100%);
   -webkit-background-clip: text;


### PR DESCRIPTION
The toc permalink was showing on the main "idfkit" hero title,
which is unnecessary for a landing page hero element.

https://claude.ai/code/session_01MtZ6ztrtEs3Y2kwrQg9e93