### PR TITLE
Include docs/snippets in pyright type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ check: ## Run code quality tools.
 	@echo "🚀 Linting code: Running pre-commit"
 	@uv run pre-commit run -a
 	@echo "🚀 Static type checking: Running pyright"
-	@uv run pyright src/
+	@uv run pyright src/ docs/snippets
 	@echo "🚀 Checking for obsolete dependencies: Running deptry"
 	@uv run deptry src
 


### PR DESCRIPTION
The `make check` target only ran pyright on `src/`, so the
docs/snippets execution environment configured in pyproject.toml
was never actually exercised. Add `docs/snippets` to the pyright
invocation so documentation code examples are type-checked too.

https://claude.ai/code/session_01KpzKJfBfGs9zK46CNg5YJ8