### PR TITLE
Fix pipe character rendering in documentation tables

### DIFF
--- a/docs/simulation/batch.md
+++ b/docs/simulation/batch.md
@@ -23,17 +23,17 @@ Define individual simulations with `SimulationJob`:
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `model` | `IDFDocument` | Required | EnergyPlus model |
-| `weather` | `str \| Path` | Required | Weather file path |
+| `weather` | <code>str &#124; Path</code> | Required | Weather file path |
 | `label` | `str` | `""` | Human-readable label |
-| `output_dir` | `str \| Path \| None` | `None` | Output directory |
+| `output_dir` | <code>str &#124; Path &#124; None</code> | `None` | Output directory |
 | `expand_objects` | `bool` | `True` | Run ExpandObjects |
 | `annual` | `bool` | `False` | Annual simulation |
 | `design_day` | `bool` | `False` | Design-day-only |
 | `output_prefix` | `str` | `"eplus"` | Output file prefix |
-| `output_suffix` | `"C" \| "L" \| "D"` | `"C"` | Output naming style |
+| `output_suffix` | <code>"C" &#124; "L" &#124; "D"</code> | `"C"` | Output naming style |
 | `readvars` | `bool` | `False` | Run ReadVarsESO |
 | `timeout` | `float` | `3600.0` | Max runtime (seconds) |
-| `extra_args` | `tuple[str, ...] \| None` | `None` | Extra CLI args |
+| `extra_args` | <code>tuple[str, ...] &#124; None</code> | `None` | Extra CLI args |
 
 ## Parametric Studies
 

--- a/docs/simulation/progress.md
+++ b/docs/simulation/progress.md
@@ -61,13 +61,13 @@ Each callback invocation receives a `SimulationProgress` event:
 |-------|------|-------------|
 | `phase` | `str` | `"initializing"`, `"warmup"`, `"simulating"`, `"postprocessing"`, or `"complete"` |
 | `message` | `str` | Raw EnergyPlus stdout line (stripped) |
-| `percent` | `float \| None` | Estimated 0-100 completion, or `None` when indeterminate |
-| `environment` | `str \| None` | Current simulation environment name |
-| `warmup_day` | `int \| None` | Current warmup iteration (1-based) |
-| `sim_day` | `int \| None` | Current day-of-year (1-based) |
-| `sim_total_days` | `int \| None` | Total simulation days when known |
-| `job_index` | `int \| None` | Batch job index (only set in batch mode) |
-| `job_label` | `str \| None` | Batch job label (only set in batch mode) |
+| `percent` | <code>float &#124; None</code> | Estimated 0-100 completion, or `None` when indeterminate |
+| `environment` | <code>str &#124; None</code> | Current simulation environment name |
+| `warmup_day` | <code>int &#124; None</code> | Current warmup iteration (1-based) |
+| `sim_day` | <code>int &#124; None</code> | Current day-of-year (1-based) |
+| `sim_total_days` | <code>int &#124; None</code> | Total simulation days when known |
+| `job_index` | <code>int &#124; None</code> | Batch job index (only set in batch mode) |
+| `job_label` | <code>str &#124; None</code> | Batch job label (only set in batch mode) |
 
 ### Simulation Phases
 

--- a/docs/simulation/results.md
+++ b/docs/simulation/results.md
@@ -109,7 +109,7 @@ Inspect results from a previous simulation:
 |-----------|------|-------------|
 | `run_dir` | `Path` | Directory containing output files |
 | `success` | `bool` | Whether simulation succeeded |
-| `exit_code` | `int \| None` | Process exit code (None if timed out) |
+| `exit_code` | <code>int &#124; None</code> | Process exit code (None if timed out) |
 | `stdout` | `str` | Captured standard output |
 | `stderr` | `str` | Captured standard error |
 | `runtime_seconds` | `float` | Wall-clock execution time |
@@ -120,17 +120,17 @@ Inspect results from a previous simulation:
 | Property | Type | Description |
 |----------|------|-------------|
 | `errors` | `ErrorReport` | Parsed error/warning report |
-| `sql` | `SQLResult \| None` | SQL database accessor |
-| `variables` | `OutputVariableIndex \| None` | Variable discovery |
-| `csv` | `CSVResult \| None` | CSV output parser |
-| `html` | `HTMLResult \| None` | HTML tabular output parser |
-| `sql_path` | `Path \| None` | Path to .sql file |
-| `err_path` | `Path \| None` | Path to .err file |
-| `eso_path` | `Path \| None` | Path to .eso file |
-| `csv_path` | `Path \| None` | Path to .csv file |
-| `html_path` | `Path \| None` | Path to HTML file |
-| `rdd_path` | `Path \| None` | Path to .rdd file |
-| `mdd_path` | `Path \| None` | Path to .mdd file |
+| `sql` | <code>SQLResult &#124; None</code> | SQL database accessor |
+| `variables` | <code>OutputVariableIndex &#124; None</code> | Variable discovery |
+| `csv` | <code>CSVResult &#124; None</code> | CSV output parser |
+| `html` | <code>HTMLResult &#124; None</code> | HTML tabular output parser |
+| `sql_path` | <code>Path &#124; None</code> | Path to .sql file |
+| `err_path` | <code>Path &#124; None</code> | Path to .err file |
+| `eso_path` | <code>Path &#124; None</code> | Path to .eso file |
+| `csv_path` | <code>Path &#124; None</code> | Path to .csv file |
+| `html_path` | <code>Path &#124; None</code> | Path to HTML file |
+| `rdd_path` | <code>Path &#124; None</code> | Path to .rdd file |
+| `mdd_path` | <code>Path &#124; None</code> | Path to .mdd file |
 
 ## See Also
 

--- a/docs/weather/downloads.md
+++ b/docs/weather/downloads.md
@@ -17,7 +17,7 @@ The `download()` method returns a `WeatherFiles` object:
 |-----------|------|-------------|
 | `epw` | `Path` | Path to the EPW file |
 | `ddy` | `Path` | Path to the DDY file |
-| `stat` | `Path \| None` | Path to the STAT file (may be None) |
+| `stat` | <code>Path &#124; None</code> | Path to the STAT file (may be None) |
 | `zip_path` | `Path` | Path to the original downloaded ZIP archive |
 | `station` | `WeatherStation` | The station this download corresponds to |
 


### PR DESCRIPTION
## Summary
This PR fixes the rendering of pipe characters (`|`) in documentation markdown tables by replacing them with HTML entity encoding (`&#124;`). This ensures proper display of union type annotations in the generated documentation.

## Changes
- **docs/simulation/results.md**: Encoded pipe characters in type annotations for `SimulationResult` and `SimulationOutput` property tables
- **docs/simulation/progress.md**: Encoded pipe characters in type annotations for `SimulationProgress` event properties
- **docs/simulation/batch.md**: Encoded pipe characters in type annotations for `SimulationJob` attributes
- **docs/weather/downloads.md**: Encoded pipe characters in type annotations for `WeatherFiles` properties

## Details
The changes convert union type syntax from backtick-enclosed markdown (e.g., `` `int | None` ``) to HTML entity-encoded format within `<code>` tags (e.g., `<code>int &#124; None</code>`). This prevents markdown table parsers from misinterpreting the pipe character as a column delimiter, ensuring type annotations render correctly in the final documentation output.

https://claude.ai/code/session_01GiYLokRxS5aGeKiok2rRgw