### PR TITLE
Improve docstrings for output variables, meters, and SQL metadata

### DIFF
--- a/src/idfkit/simulation/parsers/rdd.py
+++ b/src/idfkit/simulation/parsers/rdd.py
@@ -32,7 +32,12 @@ _MDD_RE = re.compile(
 
 @dataclass(frozen=True, slots=True)
 class OutputVariable:
-    """An available output variable from a .rdd file.
+    """An available output variable from a ``.rdd`` file.
+
+    Unlike meters, variables are associated with a specific key (zone,
+    surface, etc.).  For post-simulation SQL results where variables and
+    meters are stored together, see
+    :class:`~idfkit.simulation.parsers.sql.VariableInfo`.
 
     Attributes:
         key: The key value (e.g. ``"*"`` or ``"ZONE 1"``).
@@ -49,7 +54,12 @@ class OutputVariable:
 
 @dataclass(frozen=True, slots=True)
 class OutputMeter:
-    """An available meter from a .mdd file.
+    """An available meter from a ``.mdd`` file.
+
+    Meters aggregate energy or resource consumption and have no key value,
+    unlike :class:`OutputVariable`.  For post-simulation SQL results where
+    variables and meters are stored together, see
+    :class:`~idfkit.simulation.parsers.sql.VariableInfo`.
 
     Attributes:
         name: The meter name (e.g. ``"Electricity:Facility"``).

--- a/src/idfkit/simulation/parsers/sql.py
+++ b/src/idfkit/simulation/parsers/sql.py
@@ -115,11 +115,20 @@ class TabularRow:
 
 @dataclass(frozen=True, slots=True)
 class VariableInfo:
-    """Metadata about an available variable in the SQL database.
+    """Metadata about an available variable or meter in the SQL database.
+
+    This class represents both regular variables and meters because EnergyPlus
+    stores them in a single ``ReportDataDictionary`` table, distinguished only
+    by an ``IsMeter`` column.  Use the :attr:`is_meter` flag to tell them
+    apart.
+
+    For pre-simulation discovery from ``.rdd`` / ``.mdd`` files, see the
+    separate :class:`~idfkit.simulation.parsers.rdd.OutputVariable` and
+    :class:`~idfkit.simulation.parsers.rdd.OutputMeter` classes instead.
 
     Attributes:
         name: The variable name.
-        key_value: The key value.
+        key_value: The key value.  Empty for meters.
         frequency: The reporting frequency.
         units: The variable units.
         is_meter: Whether this is a meter (vs. a regular variable).


### PR DESCRIPTION
## Summary
Enhanced documentation for classes that represent EnergyPlus simulation output metadata by adding cross-references between related classes and clarifying the distinctions between variables and meters.

## Key Changes
- **OutputVariable docstring**: Updated file reference from `.rdd` to `` `.rdd` `` (inline code formatting) and added explanation of how variables differ from meters, with a cross-reference to `VariableInfo` for SQL results
- **OutputMeter docstring**: Updated file reference from `.mdd` to `` `.mdd` `` (inline code formatting) and added explanation that meters aggregate consumption without key values, with a cross-reference to `VariableInfo` for SQL results
- **VariableInfo docstring**: 
  - Changed description from "variable" to "variable or meter" to reflect that the class represents both
  - Added explanation that EnergyPlus stores both in a single `ReportDataDictionary` table, distinguished by an `IsMeter` column
  - Added cross-references to the separate `OutputVariable` and `OutputMeter` classes for pre-simulation discovery
  - Clarified that `key_value` is empty for meters

## Implementation Details
These are purely documentation improvements with no functional code changes. The updates establish clearer relationships between the pre-simulation discovery classes (`.rdd`/`.mdd` files) and the post-simulation SQL metadata classes, helping users understand when to use each API.

https://claude.ai/code/session_01BkozQC3RwHbVdsKdNkRckB