### PR TITLE
Fix strict IDF parser error handling and diagnostics

### DIFF
--- a/src/idfkit/__init__.py
+++ b/src/idfkit/__init__.py
@@ -38,6 +38,7 @@ from .exceptions import (
     EnergyPlusNotFoundError,
     ExpandObjectsError,
     IdfKitError,
+    IDFParseError,
     NoDesignDaysError,
     ParseError,
     RangeError,
@@ -132,13 +133,19 @@ from .zoning import (
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
-def load_idf(path: str, version: tuple[int, int, int] | None = None) -> IDFDocument:
+def load_idf(
+    path: str,
+    version: tuple[int, int, int] | None = None,
+    *,
+    strict: bool = True,
+) -> IDFDocument:
     """
     Load an IDF file and return an IDFDocument.
 
     Args:
         path: Path to the IDF file
         version: Optional version override (major, minor, patch)
+        strict: If True, fail fast on malformed IDF objects (default: True)
 
     Returns:
         Parsed IDFDocument
@@ -161,7 +168,7 @@ def load_idf(path: str, version: tuple[int, int, int] | None = None) -> IDFDocum
     """
     from pathlib import Path
 
-    return parse_idf(Path(path), version=version)
+    return parse_idf(Path(path), version=version, strict=strict)
 
 
 def load_epjson(path: str, version: tuple[int, int, int] | None = None) -> IDFDocument:
@@ -259,6 +266,7 @@ __all__ = [
     "IDFCollection",
     "IDFDocument",
     "IDFObject",
+    "IDFParseError",
     "IDFParser",
     "IdfKitError",
     "NoDesignDaysError",

--- a/src/idfkit/exceptions.py
+++ b/src/idfkit/exceptions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -13,6 +14,44 @@ class IdfKitError(Exception):
     """Base exception for all idfkit errors."""
 
     pass
+
+
+@dataclass(frozen=True, slots=True)
+class ParseDiagnostic:
+    """Structured parse diagnostic with best-effort source context."""
+
+    message: str
+    filepath: str | None = None
+    obj_type: str | None = None
+    obj_name: str | None = None
+    line: int | None = None
+    column: int | None = None
+
+
+class IDFParseError(IdfKitError):
+    """Raised when parsing IDF/epJSON content fails."""
+
+    diagnostics: tuple[ParseDiagnostic, ...]
+
+    def __init__(self, message: str, diagnostics: Sequence[ParseDiagnostic] | None = None) -> None:
+        self.diagnostics = tuple(diagnostics or ())
+        if self.diagnostics:
+            first = self.diagnostics[0]
+            location = "unknown location"
+            if first.filepath is not None and first.line is not None and first.column is not None:
+                location = f"{first.filepath}:{first.line}:{first.column}"
+            elif first.filepath is not None and first.line is not None:
+                location = f"{first.filepath}:{first.line}"
+            elif first.filepath is not None:
+                location = first.filepath
+            detail = f"{first.message} ({location})"
+            if first.obj_type:
+                detail += f" [object: {first.obj_type}]"
+            if first.obj_name:
+                detail += f" [name: {first.obj_name}]"
+            super().__init__(f"{message}: {detail}")
+            return
+        super().__init__(message)
 
 
 # Alias for backwards compatibility

--- a/src/idfkit/idf_parser.py
+++ b/src/idfkit/idf_parser.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .document import IDFDocument
-from .exceptions import VersionNotFoundError
+from .exceptions import IDFParseError, ParseDiagnostic, VersionNotFoundError
 from .objects import IDFObject
 
 logger = logging.getLogger(__name__)
@@ -71,6 +71,7 @@ def parse_idf(
     schema: EpJSONSchema | None = None,
     version: tuple[int, int, int] | None = None,
     encoding: str = "latin-1",
+    strict: bool = True,
 ) -> IDFDocument:
     """
     Parse an IDF file into an IDFDocument.
@@ -80,6 +81,7 @@ def parse_idf(
         schema: Optional EpJSONSchema for field ordering and type coercion
         version: Optional version override (auto-detected if not provided)
         encoding: File encoding (default: latin-1 for compatibility)
+        strict: If True, fail fast on malformed objects (default: True)
 
     Returns:
         Parsed IDFDocument
@@ -111,7 +113,7 @@ def parse_idf(
     if not filepath.exists():
         raise FileNotFoundError(f"IDF file not found: {filepath}")  # noqa: TRY003
 
-    parser = IDFParser(filepath, schema, encoding)
+    parser = IDFParser(filepath, schema, encoding, strict=strict)
     return parser.parse(version)
 
 
@@ -122,22 +124,25 @@ class IDFParser:
     Uses memory mapping for large files and regex for tokenization.
     """
 
-    __slots__ = ("_content", "_encoding", "_filepath", "_schema")
+    __slots__ = ("_content", "_encoding", "_filepath", "_schema", "_strict")
 
     _filepath: Path
     _schema: EpJSONSchema | None
     _encoding: str
     _content: bytes | None
+    _strict: bool
 
     def __init__(
         self,
         filepath: Path,
         schema: EpJSONSchema | None = None,
         encoding: str = "latin-1",
+        strict: bool = True,
     ):
         self._filepath = filepath
         self._schema = schema
         self._encoding = encoding
+        self._strict = strict
         self._content: bytes | None = None
 
     def parse(self, version: tuple[int, int, int] | None = None) -> IDFDocument:
@@ -229,31 +234,47 @@ class IDFParser:
         skipped_types: set[str] = set()
 
         for match in _OBJECT_PATTERN.finditer(content):
+            match_offset = match.start(1)
+            obj_type: str | None = None
+            obj_name: str | None = None
+
             try:
-                obj_type = match.group(1).decode(encoding).strip()
+                decoded_obj_type = match.group(1).decode(encoding).strip()
+                obj_type = decoded_obj_type
 
                 # Skip version object (handled separately)
-                if obj_type.upper() == "VERSION":
+                if decoded_obj_type.upper() == "VERSION":
                     continue
 
-                # Get or build per-type cache
-                if schema is not None:
-                    pc = type_cache.get(obj_type)
-                    if pc is None and obj_type not in type_cache:
-                        pc = schema.get_parsing_cache(obj_type)
-                        type_cache[obj_type] = pc
-                    if pc is None:
-                        skipped_types.add(obj_type)
-                        continue  # Unknown object type
-                else:
-                    pc = None
+                obj_name = self._extract_object_name(match, encoding)
+
+                pc, should_skip = self._resolve_type_cache(
+                    content=content,
+                    schema=schema,
+                    type_cache=type_cache,
+                    skipped_types=skipped_types,
+                    obj_type=decoded_obj_type,
+                    obj_name=obj_name,
+                    match_offset=match_offset,
+                )
+                if should_skip:
+                    continue
 
                 obj = self._parse_object_cached(match, pc, encoding)
                 if obj:
                     addidfobject(obj)
-            except Exception:  # noqa: S110
-                # Log parse errors but continue
-                pass
+            except IDFParseError:
+                raise
+            except Exception as exc:
+                if self._strict:
+                    self._raise_parse_error(
+                        content,
+                        match_offset,
+                        f"Failed to parse object: {exc}",
+                        obj_type=obj_type,
+                        obj_name=obj_name,
+                    )
+                logger.warning("Skipping malformed object %r: %s", obj_type or "<decode_error>", exc)
 
         if skipped_types:
             logger.warning(
@@ -320,25 +341,57 @@ class IDFParser:
                 else:
                     data[field_name] = ""
 
-        # Handle extensible fields
+        if not pc.extensible and len(remaining_fields) > num_named and self._strict:
+            overflow = len(remaining_fields) - num_named
+            msg = (
+                f"Object has {overflow} extra field(s) but type is not extensible "
+                f"(expected at most {num_named}, got {len(remaining_fields)})"
+            )
+            raise ValueError(msg)
+
         if pc.extensible and num_named < len(remaining_fields):
-            ext_size = pc.ext_size
-            ext_names = pc.ext_field_names
-            num_ext = len(ext_names)
             extra = remaining_fields[num_named:]
-            for group_idx in range(0, len(extra), ext_size):
-                group = extra[group_idx : group_idx + ext_size]
-                suffix = "" if group_idx == 0 else f"_{group_idx // ext_size + 1}"
-                for j, value in enumerate(group):
-                    if j < num_ext:
-                        ext_field = f"{ext_names[j]}{suffix}"
-                        if value:
-                            data[ext_field] = _coerce_value_fast(field_types.get(ext_names[j]), value)
-                        else:
-                            data[ext_field] = ""
-                        field_names.append(ext_field)
+            self._append_extensible_fields(
+                data=data,
+                extra=extra,
+                field_names=field_names,
+                field_types=field_types,
+                pc=pc,
+            )
 
         return data
+
+    def _append_extensible_fields(
+        self,
+        *,
+        data: dict[str, Any],
+        extra: list[str],
+        field_names: list[str],
+        field_types: dict[str, str | None],
+        pc: ParsingCache,
+    ) -> None:
+        """Append extensible field groups to parsed data."""
+        ext_size = pc.ext_size
+        if ext_size <= 0:
+            if self._strict:
+                msg = "Object is marked extensible but extensible group size is invalid"
+                raise ValueError(msg)
+            return
+
+        ext_names = pc.ext_field_names
+        num_ext = len(ext_names)
+        for group_idx in range(0, len(extra), ext_size):
+            group = extra[group_idx : group_idx + ext_size]
+            suffix = "" if group_idx == 0 else f"_{group_idx // ext_size + 1}"
+            for j, value in enumerate(group):
+                if j >= num_ext:
+                    continue
+                ext_field = f"{ext_names[j]}{suffix}"
+                if value:
+                    data[ext_field] = _coerce_value_fast(field_types.get(ext_names[j]), value)
+                else:
+                    data[ext_field] = ""
+                field_names.append(ext_field)
 
     def _parse_fields(self, fields_raw: str) -> list[str]:
         """Parse and clean field values from raw string."""
@@ -355,6 +408,73 @@ class IDFParser:
             lines.append(line)
         clean_text = " ".join(lines)
         return [part.strip() for part in clean_text.split(",")]
+
+    @staticmethod
+    def _line_and_column(content: bytes, offset: int) -> tuple[int, int]:
+        """Convert a byte offset to 1-based (line, column)."""
+        line = content.count(b"\n", 0, offset) + 1
+        previous_newline = content.rfind(b"\n", 0, offset)
+        if previous_newline < 0:
+            return (line, offset + 1)
+        return (line, offset - previous_newline)
+
+    @staticmethod
+    def _extract_object_name(match: re.Match[bytes], encoding: str) -> str | None:
+        """Best-effort extraction of the raw first field (typically object name)."""
+        fields_raw = match.group(2).decode(encoding)
+        first = fields_raw.split(",", maxsplit=1)[0].strip()
+        return first or None
+
+    def _raise_parse_error(
+        self,
+        content: bytes,
+        offset: int,
+        message: str,
+        *,
+        obj_type: str | None = None,
+        obj_name: str | None = None,
+    ) -> None:
+        """Raise a ParseError with contextual diagnostics."""
+        line, column = self._line_and_column(content, offset)
+        diagnostic = ParseDiagnostic(
+            message=message,
+            filepath=str(self._filepath),
+            obj_type=obj_type,
+            obj_name=obj_name,
+            line=line,
+            column=column,
+        )
+        summary = "Failed to parse IDF"
+        raise IDFParseError(summary, diagnostics=[diagnostic])
+
+    def _resolve_type_cache(
+        self,
+        *,
+        content: bytes,
+        schema: EpJSONSchema | None,
+        type_cache: dict[str, ParsingCache | None],
+        skipped_types: set[str],
+        obj_type: str,
+        obj_name: str | None,
+        match_offset: int,
+    ) -> tuple[ParsingCache | None, bool]:
+        """Resolve and cache parsing metadata for an object type."""
+        if schema is None:
+            return (None, False)
+
+        pc = type_cache.get(obj_type)
+        if pc is None and obj_type not in type_cache:
+            pc = schema.get_parsing_cache(obj_type)
+            type_cache[obj_type] = pc
+
+        if pc is not None:
+            return (pc, False)
+
+        if self._strict:
+            msg = f"Unknown object type '{obj_type}'"
+            self._raise_parse_error(content, match_offset, msg, obj_type=obj_type, obj_name=obj_name)
+        skipped_types.add(obj_type)
+        return (None, True)
 
 
 def iter_idf_objects(

--- a/tests/test_idf_roundtrip.py
+++ b/tests/test_idf_roundtrip.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from idfkit.exceptions import IDFParseError
 from idfkit.idf_parser import parse_idf
 from idfkit.schema import get_schema
 from idfkit.writers import write_idf
@@ -172,8 +173,8 @@ class TestPhantomObjects:
         obj_types = set(doc.collections.keys())
         assert "Minimal IDF for roundtrip testing" not in obj_types
 
-    def test_unknown_type_filtered(self, tmp_path: Path) -> None:
-        """Garbage text matching the object regex should be filtered out."""
+    def test_unknown_type_raises(self, tmp_path: Path) -> None:
+        """Garbage text matching the object regex should fail strict parsing."""
         content = """\
 Version, 24.1;
 
@@ -186,10 +187,8 @@ Zone,
 """
         filepath = tmp_path / "phantom.idf"
         filepath.write_text(content, encoding="latin-1")
-        doc = parse_idf(filepath)
-        obj_types = set(doc.collections.keys())
-        assert "design days" not in obj_types
-        assert "Zone" in obj_types
+        with pytest.raises(IDFParseError, match="Unknown object type"):
+            parse_idf(filepath)
 
 
 class TestExtensibleFieldsWithEmptyValues:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -10,7 +10,7 @@ import pytest
 from idfkit import load_epjson, load_idf
 from idfkit.epjson_parser import get_epjson_version, parse_epjson
 from idfkit.epjson_parser import load_epjson as raw_load_epjson
-from idfkit.exceptions import VersionNotFoundError
+from idfkit.exceptions import IDFParseError, VersionNotFoundError
 from idfkit.idf_parser import get_idf_version, iter_idf_objects, parse_idf
 
 # ---------------------------------------------------------------------------
@@ -334,3 +334,58 @@ Sizing:Zone,
         assert after_fields == original_fields, (
             f"Schema was mutated: started with {original_fields}, now {after_fields}"
         )
+
+    def test_non_extensible_overflow_raises(self, tmp_path: Path) -> None:
+        """Strict parsing should fail when non-extensible objects overflow fields."""
+        content = """\
+Version,24.1;
+Building,
+  My Building,
+  0.0,
+  Suburbs,
+  0.04,
+  0.4,
+  FullExterior,
+  25,
+  6,
+  UnexpectedTrailingField;
+"""
+        filepath = tmp_path / "overflow.idf"
+        filepath.write_text(content)
+        with pytest.raises(IDFParseError, match="not extensible") as exc_info:
+            parse_idf(filepath)
+        assert exc_info.value.diagnostics
+        assert exc_info.value.diagnostics[0].line is not None
+
+    def test_unknown_object_type_raises(self, tmp_path: Path) -> None:
+        """Strict parsing should fail on unknown object types instead of silently skipping."""
+        content = """\
+Version,24.1;
+Zone, KnownZone;
+TotallyMadeUpObject, Foo;
+"""
+        filepath = tmp_path / "unknown_type.idf"
+        filepath.write_text(content)
+        with pytest.raises(IDFParseError, match="Unknown object type") as exc_info:
+            parse_idf(filepath)
+        assert exc_info.value.diagnostics[0].obj_type == "TotallyMadeUpObject"
+
+    def test_invalid_field_bytes_strict_false_skips(self, tmp_path: Path) -> None:
+        """Malformed bytes should be skipped (not leaked as UnicodeDecodeError) when strict=False."""
+        content = b"Version,24.1;\nZone,\n  Bad\xffName,\n  0,0,0,0;\n"
+        filepath = tmp_path / "bad_bytes.idf"
+        filepath.write_bytes(content)
+
+        doc = parse_idf(filepath, encoding="utf-8", strict=False)
+        assert len(doc["Zone"]) == 0
+
+    def test_invalid_field_bytes_strict_true_wrapped(self, tmp_path: Path) -> None:
+        """Malformed bytes should raise IDFParseError with diagnostics when strict=True."""
+        content = b"Version,24.1;\nZone,\n  Bad\xffName,\n  0,0,0,0;\n"
+        filepath = tmp_path / "bad_bytes_strict.idf"
+        filepath.write_bytes(content)
+
+        with pytest.raises(IDFParseError, match="Failed to parse object") as exc_info:
+            parse_idf(filepath, encoding="utf-8", strict=True)
+        assert exc_info.value.diagnostics
+        assert exc_info.value.diagnostics[0].obj_type == "Zone"


### PR DESCRIPTION
## Summary
- add strict parsing controls to IDF loading (`strict=True` by default)
- raise structured `IDFParseError` diagnostics for unknown object types and malformed objects
- prevent silent swallowing of object-level parse failures
- move `obj_type`/`obj_name` decoding into the guarded parse path so invalid bytes are handled consistently
- add regression tests for overflow fields, unknown object types, and malformed-byte strict/non-strict behavior

## Validation
- `make check`
- `make test`
- `uv run pytest tests/test_parsers.py tests/test_idf_roundtrip.py -q`

Closes #63
