### PR TITLE
docs: align load_idf docs with strict parsing default

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ for obj in doc.get_referencing("Office"):
 write_idf(doc, "out.idf")
 ```
 
+> **Note:** `load_idf()` defaults to strict parsing (`strict=True`) and raises
+> `IDFParseError` on malformed objects. Use `strict=False` only as a tolerant
+> migration/compatibility fallback for legacy or noisy files.
+
 ### Creating a model from scratch
 
 ```python

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -3,6 +3,18 @@
 Functions and classes for reading and writing EnergyPlus models in IDF
 (text) and epJSON (JSON) formats.
 
+## Convenience Loaders
+
+Top-level convenience functions:
+
+- `load_idf(path, version=None, *, strict=True)` for IDF files. Strict parsing
+  is on by default.
+- `load_epjson(path, version=None)` for epJSON files.
+
+::: idfkit.load_idf
+
+::: idfkit.load_epjson
+
 ## IDF Parser
 
 ::: idfkit.idf_parser

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -9,6 +9,10 @@ operations you'll use every day.
 --8<-- "docs/snippets/getting-started/quick-start/load_a_model.py:example"
 ```
 
+`load_idf()` uses strict parsing by default (`strict=True`) and raises
+`IDFParseError` for malformed objects. Use `strict=False` only as a
+migration/compatibility fallback for legacy or noisy files.
+
 ## Query Objects
 
 Access objects with O(1) dictionary lookups:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -274,17 +274,26 @@ Translate or rotate all surfaces in the model:
 
 ## Strict field access (new in idfkit)
 
+idfkit has two different strictness settings:
+
+- **Strict parsing** (`load_idf(..., strict=True)`) validates IDF input while
+  reading and is enabled by default.
+- **Strict field access** (`doc.strict = True`) raises on mistyped attribute
+  names when reading or writing object fields.
+
 eppy silently returns an empty string when you mistype a field name,
 making bugs hard to find. idfkit defaults to the same behaviour for
-compatibility, but you can opt in to **strict mode** to catch typos
+compatibility at field-access time, but you can opt in to **strict field
+access** to catch typos
 immediately:
 
 ```python
 --8<-- "docs/snippets/migration/strict_mode.py:example"
 ```
 
-Enable strict mode during migration to surface field-name mismatches
-early. Once your code is clean you can leave it on or turn it off.
+Enable strict field access during migration to surface field-name
+mismatches early. Once your code is clean you can leave it on or turn it
+off.
 
 ## Running a simulation
 

--- a/docs/snippets/getting-started/quick-start/load_a_model.py
+++ b/docs/snippets/getting-started/quick-start/load_a_model.py
@@ -9,4 +9,8 @@ from idfkit import load_idf
 # Load an existing IDF file
 model = load_idf("building.idf")
 print(f"Loaded {len(model)} objects")
+
+# For migration-only tolerant loading of legacy/noisy files:
+model = load_idf("legacy_building.idf", strict=False)
+print(f"Tolerant load parsed {len(model)} objects")
 # --8<-- [end:example]

--- a/docs/troubleshooting/errors.md
+++ b/docs/troubleshooting/errors.md
@@ -193,16 +193,28 @@ model.add(
 ### Invalid IDF Syntax
 
 ```
-ValueError: Failed to parse IDF at line 42
+IDFParseError: Failed to parse object
 ```
 
-**Cause:** The IDF file has invalid syntax.
+**Cause:** `load_idf()` uses strict parsing by default
+(`strict=True`) and found malformed content (for example unknown object
+types, invalid bytes, or extra fields on non-extensible objects).
 
 **Solutions:**
 
 1. Check for unclosed objects (missing `;`)
 2. Check for invalid field separators
 3. Validate with EnergyPlus directly first
+4. For migration or best-effort loading of legacy/noisy files, use
+   tolerant parsing:
+   ```python
+   from idfkit import IDFParseError, load_idf
+
+   try:
+       doc = load_idf("file.idf")  # strict=True (default)
+   except IDFParseError:
+       doc = load_idf("file.idf", strict=False)
+   ```
 
 ### Version Mismatch
 


### PR DESCRIPTION
## Summary
- document that `load_idf()` uses strict parsing by default (`strict=True`)
- update troubleshooting to reference `IDFParseError` and show `strict=False` as migration fallback
- clarify parser strictness vs field-access strictness in migration docs
- expose top-level convenience loaders (`load_idf`, `load_epjson`) in API I/O docs

## Files updated
- `docs/troubleshooting/errors.md`
- `docs/getting-started/quick-start.md`
- `docs/snippets/getting-started/quick-start/load_a_model.py`
- `docs/migration.md`
- `docs/api/io.md`
- `README.md`

## Verification
- `make check` ✅
- `uv run pytest tests/test_parsers.py -k "strict or unknown_object_type or overflow" -v` ✅
- `uv run mkdocs build --strict` ⚠️ fails in this environment due missing native Cairo (`cairosvg` warning spam), not due doc content changes
