### PR TITLE
Change experiment parameter from 'experiment' to 'runnable'

### DIFF
--- a/docs/snippets/examples/scythe/allocate.py
+++ b/docs/snippets/examples/scythe/allocate.py
@@ -29,7 +29,7 @@ df["design_day_file"] = "s3://my-bucket/weather/USA_MA_Boston-Logan.ddy"
 # Validate and allocate
 specs = [BuildingSimInput.model_validate(row.to_dict()) for _, row in df.iterrows()]
 
-experiment = BaseExperiment(experiment=simulate_building)
+experiment = BaseExperiment(runnable=simulate_building)
 experiment.allocate(
     specs,
     version="bumpminor",


### PR DESCRIPTION
This pull request updates the instantiation of the `BaseExperiment` class in the `scythe/allocate.py` example to use the `runnable` keyword argument instead of the deprecated `experiment` argument.

- Updated the `BaseExperiment` initialization to use `runnable=simulate_building` for compatibility with the latest API, replacing the old `experiment` argument.