### PR TITLE
Improve exception hierarchy with docs URLs and base class inheritance

### DIFF
--- a/docs/idfkit-dev-guide.md
+++ b/docs/idfkit-dev-guide.md
@@ -206,9 +206,14 @@ intersect_match(doc)
 All exceptions inherit from `IdfKitError`:
 
 - `IDFParseError`, `ParseError` — parsing failures
-- `UnknownObjectTypeError` — invalid IDF object type
+- `UnknownObjectTypeError` (also `KeyError`) — invalid IDF object type name
+- `InvalidFieldError` — invalid field name on an object (strict mode, on by default)
 - `DuplicateObjectError` — singleton constraint violation
+- `DanglingReferenceError` — object references a non-existent target
+- `RangeError` — field value outside valid range
 - `ValidationFailedError` — validation errors
-- `SimulationError`, `EnergyPlusNotFoundError` — simulation failures
+- `SimulationError`, `EnergyPlusNotFoundError`, `ExpandObjectsError` — simulation failures
+- `NoDesignDaysError` — DDY file has no design day objects
+- `UnsupportedVersionError` — requested version not in supported range
 - `VersionNotFoundError`, `SchemaNotFoundError` — version/schema issues
 ````

--- a/src/idfkit/__init__.py
+++ b/src/idfkit/__init__.py
@@ -45,12 +45,14 @@ from .exceptions import (
     ExpandObjectsError,
     IdfKitError,
     IDFParseError,
+    InvalidFieldError,
     NoDesignDaysError,
     ParseError,
     RangeError,
     SchemaNotFoundError,
     SimulationError,
     UnknownObjectTypeError,
+    UnsupportedVersionError,
     ValidationFailedError,
     VersionNotFoundError,
 )
@@ -148,6 +150,12 @@ from .zoning import (
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
+def _check_version(version: tuple[int, int, int]) -> None:
+    """Raise UnsupportedVersionError if *version* is not a known EnergyPlus release."""
+    if not is_supported_version(version):
+        raise UnsupportedVersionError(version, ENERGYPLUS_VERSIONS)
+
+
 @overload
 def load_idf(
     path: str,
@@ -219,6 +227,8 @@ def load_idf(  # type: ignore[misc]  # overload implementation
     """
     from pathlib import Path
 
+    if version is not None:
+        _check_version(version)
     return parse_idf(
         Path(path),
         version=version,
@@ -287,6 +297,8 @@ def load_epjson(  # type: ignore[misc]  # overload implementation
     """
     from pathlib import Path
 
+    if version is not None:
+        _check_version(version)
     return parse_epjson(
         Path(path), version=version, strict_fields=strict_fields, preserve_formatting=preserve_formatting
     )
@@ -348,6 +360,7 @@ def new_document(  # type: ignore[misc]  # overload implementation
         >>> model_v24.version
         (24, 1, 0)
     """
+    _check_version(version)
     schema = get_schema(version)
     doc = IDFDocument(version=version, schema=schema, strict=strict)  # type: ignore[reportCallIssue]  # .pyi uses covariant Strict
 
@@ -383,6 +396,7 @@ __all__ = [
     "IDFParseError",
     "IDFParser",
     "IdfKitError",
+    "InvalidFieldError",
     "NoDesignDaysError",
     "ObjectDescription",
     "ParseError",
@@ -393,6 +407,7 @@ __all__ = [
     "SchemaNotFoundError",
     "SimulationError",
     "UnknownObjectTypeError",
+    "UnsupportedVersionError",
     "ValidationError",
     "ValidationFailedError",
     "ValidationResult",

--- a/src/idfkit/document.py
+++ b/src/idfkit/document.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from ._compat import EppyDocumentMixin
 from .cst import DocumentCST
-from .exceptions import DuplicateObjectError, ValidationFailedError
+from .exceptions import DuplicateObjectError, UnknownObjectTypeError, ValidationFailedError
 from .introspection import ObjectDescription, describe_object_type
 from .objects import IDFCollection, IDFObject
 from .references import ReferenceGraph
@@ -352,7 +352,7 @@ class IDFDocument(EppyDocumentMixin, Generic[Strict]):
 
         Raises:
             ValueError: If no schema is loaded
-            KeyError: If the object type is not found in the schema
+            UnknownObjectTypeError: If the object type is not found in the schema
 
         Examples:
             Discover which fields are needed for a new Material:
@@ -469,6 +469,8 @@ class IDFDocument(EppyDocumentMixin, Generic[Strict]):
             The created IDFObject
 
         Raises:
+            UnknownObjectTypeError: If the object type is not recognised by
+                the schema
             DuplicateObjectError: If a singleton object type (marked with
                 schema ``maxProperties == 1``) already exists in the document
             ValidationFailedError: If validation fails (unknown fields, missing
@@ -520,8 +522,11 @@ class IDFDocument(EppyDocumentMixin, Generic[Strict]):
             resolved_obj_type = self._resolve_schema_obj_type(obj_type)
             obj_schema = self._schema.get_object_schema(resolved_obj_type)
 
+            if obj_schema is None:
+                raise UnknownObjectTypeError(obj_type, version=self.version)
+
             # Enforce singleton object types (schema marker: maxProperties == 1).
-            if obj_schema and obj_schema.get("maxProperties") == 1:
+            if obj_schema.get("maxProperties") == 1:
                 existing_type = self._find_existing_collection_type(resolved_obj_type)
                 if existing_type is not None:
                     existing = self._collections[existing_type].first()

--- a/src/idfkit/exceptions.py
+++ b/src/idfkit/exceptions.py
@@ -58,6 +58,22 @@ class IDFParseError(IdfKitError):
 ParseError = IdfKitError
 
 
+class UnsupportedVersionError(IdfKitError):
+    """Raised when a non-existent EnergyPlus version is requested.
+
+    Attributes:
+        version: The requested version tuple.
+        supported_versions: Tuple of all supported version tuples.
+    """
+
+    def __init__(self, version: tuple[int, int, int], supported_versions: Sequence[tuple[int, int, int]]) -> None:
+        self.version = version
+        self.supported_versions = tuple(supported_versions)
+        version_str = f"{version[0]}.{version[1]}.{version[2]}"
+        supported_strs = ", ".join(f"{v[0]}.{v[1]}.{v[2]}" for v in self.supported_versions)
+        super().__init__(f"EnergyPlus version {version_str} is not supported.\nSupported versions: {supported_strs}")
+
+
 class SchemaNotFoundError(IdfKitError):
     """Raised when the EpJSON schema file cannot be found."""
 
@@ -80,26 +96,56 @@ class DuplicateObjectError(IdfKitError):
         super().__init__(f"Duplicate {obj_type} object with name '{name}'")
 
 
-class UnknownObjectTypeError(IdfKitError):
-    """Raised when an unknown object type is encountered."""
+class UnknownObjectTypeError(IdfKitError, KeyError):
+    """Raised when an unknown object type is encountered.
 
-    def __init__(self, obj_type: str) -> None:
+    Inherits from ``KeyError`` so that existing code catching ``KeyError``
+    for missing object types continues to work.
+    """
+
+    def __init__(self, obj_type: str, version: tuple[int, int, int] | None = None) -> None:
         self.obj_type = obj_type
-        super().__init__(f"Unknown object type: '{obj_type}'")
+        self.version = version
+        msg = f"Unknown object type: '{obj_type}'"
+        if version:
+            from .docs import search_url
+
+            s_url = search_url(obj_type, version)
+            if s_url:
+                msg += f"\n  Search docs: {s_url.url}"
+        super().__init__(msg)
 
 
-class InvalidFieldError(IdfKitError):
-    """Raised when an invalid field is accessed or set."""
+class InvalidFieldError(IdfKitError, AttributeError):
+    """Raised when an invalid field is accessed or set.
 
-    def __init__(self, obj_type: str, field_name: str, available_fields: list[str] | None = None) -> None:
+    Inherits from ``AttributeError`` so that Python's attribute access
+    protocol (``hasattr``, ``getattr`` with default) continues to work
+    correctly when this is raised from ``__getattr__``.
+    """
+
+    def __init__(
+        self,
+        obj_type: str,
+        field_name: str,
+        available_fields: list[str] | None = None,
+        version: tuple[int, int, int] | None = None,
+    ) -> None:
         self.obj_type = obj_type
         self.field_name = field_name
         self.available_fields = available_fields
+        self.version = version
         msg = f"Invalid field '{field_name}' for object type '{obj_type}'"
         if available_fields:
             msg += f"\nAvailable fields: {', '.join(available_fields[:10])}"
             if len(available_fields) > 10:
                 msg += f" ... and {len(available_fields) - 10} more"
+        if version:
+            from .docs import io_reference_url
+
+            doc_url = io_reference_url(obj_type, version)
+            if doc_url:
+                msg += f"\n  Docs: {doc_url.url}"
         super().__init__(msg)
 
 

--- a/src/idfkit/introspection.py
+++ b/src/idfkit/introspection.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from .exceptions import UnknownObjectTypeError
+
 if TYPE_CHECKING:
     from .schema import EpJSONSchema
 
@@ -187,12 +189,11 @@ def describe_object_type(schema: EpJSONSchema, obj_type: str) -> ObjectDescripti
         ObjectDescription with detailed field information
 
     Raises:
-        KeyError: If the object type is not found in the schema
+        UnknownObjectTypeError: If the object type is not found in the schema
     """
     obj_schema = schema.get_object_schema(obj_type)
     if not obj_schema:
-        msg = f"Unknown object type: {obj_type}"
-        raise KeyError(msg)
+        raise UnknownObjectTypeError(obj_type, version=schema.version)
 
     inner_schema = schema.get_inner_schema(obj_type)
     properties: dict[str, Any] = inner_schema.get("properties", {}) if inner_schema else {}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from idfkit.exceptions import (
     DanglingReferenceError,
     DuplicateObjectError,
@@ -12,10 +14,12 @@ from idfkit.exceptions import (
     SchemaNotFoundError,
     SimulationError,
     UnknownObjectTypeError,
+    UnsupportedVersionError,
     ValidationFailedError,
     VersionNotFoundError,
 )
 from idfkit.objects import IDFObject
+from idfkit.versions import ENERGYPLUS_VERSIONS
 
 
 class TestIdfKitError:
@@ -181,3 +185,64 @@ class TestExpandObjectsError:
         assert sim_err.exit_code == 2
         assert expand_err.stderr == "err1"
         assert sim_err.stderr == "err2"
+
+
+class TestUnsupportedVersionError:
+    def test_basic(self) -> None:
+        err = UnsupportedVersionError((9, 8, 0), ENERGYPLUS_VERSIONS)
+        assert err.version == (9, 8, 0)
+        assert "9.8.0" in str(err)
+        assert "is not supported" in str(err)
+
+    def test_lists_supported_versions(self) -> None:
+        err = UnsupportedVersionError((99, 0, 0), ENERGYPLUS_VERSIONS)
+        assert "8.9.0" in str(err)
+        assert "25.2.0" in str(err)
+
+    def test_stores_supported_versions(self) -> None:
+        err = UnsupportedVersionError((9, 8, 0), ENERGYPLUS_VERSIONS)
+        assert err.supported_versions == ENERGYPLUS_VERSIONS
+
+    def test_is_idfkit_error(self) -> None:
+        assert isinstance(UnsupportedVersionError((1, 0, 0), ()), IdfKitError)
+
+
+class TestUnsupportedVersionIntegration:
+    def test_new_document_rejects_unsupported_version(self) -> None:
+        from idfkit import new_document
+
+        with pytest.raises(UnsupportedVersionError, match=r"9\.8\.0"):
+            new_document(version=(9, 8, 0))
+
+    def test_new_document_rejects_nonexistent_version(self) -> None:
+        from idfkit import new_document
+
+        with pytest.raises(UnsupportedVersionError, match=r"99\.0\.0"):
+            new_document(version=(99, 0, 0))
+
+    def test_new_document_accepts_supported_version(self) -> None:
+        from idfkit import new_document
+
+        doc = new_document(version=(24, 1, 0))
+        assert doc.version == (24, 1, 0)
+
+    def test_load_idf_rejects_unsupported_version(self, tmp_path: object) -> None:
+        import pathlib
+
+        from idfkit import load_idf
+
+        idf_path = pathlib.Path(str(tmp_path)) / "test.idf"
+        idf_path.write_text("Version, 24.1;\n")
+        with pytest.raises(UnsupportedVersionError, match=r"9\.8\.0"):
+            load_idf(str(idf_path), version=(9, 8, 0))
+
+    def test_load_idf_allows_none_version(self, tmp_path: object) -> None:
+        """Auto-detected versions from files should still use closest-version fallback."""
+        import pathlib
+
+        from idfkit import load_idf
+
+        idf_path = pathlib.Path(str(tmp_path)) / "test.idf"
+        idf_path.write_text("Version, 24.1;\n")
+        doc = load_idf(str(idf_path))
+        assert doc.version == (24, 1, 0)


### PR DESCRIPTION
## Summary
- New `UnsupportedVersionError` validates version tuples early in `load_idf`, `load_epjson`, `new_document`
- `UnknownObjectTypeError` now inherits `KeyError` (backward compat for `except KeyError` patterns) and embeds docs.idfkit.com search links
- `InvalidFieldError` now inherits `AttributeError` (so `hasattr`/`getattr` with default work correctly) and embeds docs.idfkit.com I/O Reference links
- Both new exception exports added to public API
- Updated exception hierarchy documentation

Replaces #86 (closed when base branch was deleted during squash merge).

## Test plan
- [x] `make check` passes
- [x] `make test` passes (1960 tests)
- [x] New tests for `UnsupportedVersionError` (unit + integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)