### PR TITLE
Rename strict parameters for clarity

### DIFF
--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -7,9 +7,9 @@ Functions and classes for reading and writing EnergyPlus models in IDF
 
 Top-level convenience functions:
 
-- `load_idf(path, version=None, *, strict=True, strict_fields=False, preserve_formatting=False)` for IDF files. Strict parsing
+- `load_idf(path, version=None, *, strict_parsing=True, strict=False, preserve_formatting=False)` for IDF files. Strict parsing
   is on by default.
-- `load_epjson(path, version=None, *, strict_fields=False, preserve_formatting=False)` for epJSON files.
+- `load_epjson(path, version=None, *, strict=False, preserve_formatting=False)` for epJSON files.
 
 ::: idfkit.load_idf
 

--- a/docs/concepts/type-safety.md
+++ b/docs/concepts/type-safety.md
@@ -33,8 +33,8 @@ mode** to catch typos at runtime with an `AttributeError`:
 | Function | Parameter |
 |----------|-----------|
 | `new_document()` | `strict=True` |
-| `load_idf()` | `strict_fields=True` |
-| `load_epjson()` | `strict_fields=True` |
+| `load_idf()` | `strict=True` |
+| `load_epjson()` | `strict=True` |
 
 !!! tip
     Strict mode is recommended during development. Disable it when loading

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -9,8 +9,8 @@ operations you'll use every day.
 --8<-- "docs/snippets/getting-started/quick-start/load_a_model.py:example"
 ```
 
-`load_idf()` uses strict parsing by default (`strict=True`) and raises
-`IDFParseError` for malformed objects. Use `strict=False` only as a
+`load_idf()` uses strict parsing by default (`strict_parsing=True`) and raises
+`IDFParseError` for malformed objects. Use `strict_parsing=False` only as a
 migration/compatibility fallback for legacy or noisy files.
 
 ## Query Objects

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -281,9 +281,9 @@ Translate or rotate all surfaces in the model:
 
 idfkit has two different strictness settings:
 
-- **Strict parsing** (`load_idf(..., strict=True)`) validates IDF input while
+- **Strict parsing** (`load_idf(..., strict_parsing=True)`) validates IDF input while
   reading and is enabled by default.
-- **Strict field access** (`doc.strict = True`) raises on mistyped attribute
+- **Strict field access** (`load_idf(..., strict=True)`) raises on mistyped attribute
   names when reading or writing object fields.
 
 eppy silently returns an empty string when you mistype a field name,

--- a/docs/snippets/concepts/type-safety/strict_fields.py
+++ b/docs/snippets/concepts/type-safety/strict_fields.py
@@ -12,6 +12,6 @@ zone.x_origin = 0.0  # OK — valid field
 # zone.x_orgin = 0.0  # AttributeError! Typo caught immediately
 
 # Also available when loading files
-# model = load_idf("building.idf", strict_fields=True)
-# model = load_epjson("building.epJSON", strict_fields=True)
+# model = load_idf("building.idf", strict=True)
+# model = load_epjson("building.epJSON", strict=True)
 # --8<-- [end:example]

--- a/docs/snippets/getting-started/quick-start/load_a_model.py
+++ b/docs/snippets/getting-started/quick-start/load_a_model.py
@@ -11,6 +11,6 @@ model = load_idf("building.idf")
 print(f"Loaded {len(model)} objects")
 
 # For migration-only tolerant loading of legacy/noisy files:
-model = load_idf("legacy_building.idf", strict=False)
+model = load_idf("legacy_building.idf", strict_parsing=False)
 print(f"Tolerant load parsed {len(model)} objects")
 # --8<-- [end:example]

--- a/docs/troubleshooting/errors.md
+++ b/docs/troubleshooting/errors.md
@@ -197,7 +197,7 @@ IDFParseError: Failed to parse object
 ```
 
 **Cause:** `load_idf()` uses strict parsing by default
-(`strict=True`) and found malformed content (for example unknown object
+(`strict_parsing=True`) and found malformed content (for example unknown object
 types, invalid bytes, or extra fields on non-extensible objects).
 
 **Solutions:**
@@ -211,9 +211,9 @@ types, invalid bytes, or extra fields on non-extensible objects).
    from idfkit import IDFParseError, load_idf
 
    try:
-       doc = load_idf("file.idf")  # strict=True (default)
+       doc = load_idf("file.idf")  # strict_parsing=True (default)
    except IDFParseError:
-       doc = load_idf("file.idf", strict=False)
+       doc = load_idf("file.idf", strict_parsing=False)
    ```
 
 ### Version Mismatch

--- a/src/idfkit/__init__.py
+++ b/src/idfkit/__init__.py
@@ -161,8 +161,8 @@ def load_idf(
     path: str,
     version: tuple[int, int, int] | None = ...,
     *,
-    strict: bool = ...,
-    strict_fields: Literal[True],
+    strict_parsing: bool = ...,
+    strict: Literal[True],
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[True]]: ...
 
@@ -172,8 +172,8 @@ def load_idf(
     path: str,
     version: tuple[int, int, int] | None = ...,
     *,
-    strict: bool = ...,
-    strict_fields: Literal[False] = ...,
+    strict_parsing: bool = ...,
+    strict: Literal[False] = ...,
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[False]]: ...
 
@@ -182,8 +182,8 @@ def load_idf(  # type: ignore[misc]  # overload implementation
     path: str,
     version: tuple[int, int, int] | None = None,
     *,
-    strict: bool = True,
-    strict_fields: bool = False,
+    strict_parsing: bool = True,
+    strict: bool = False,
     preserve_formatting: bool = False,
 ) -> IDFDocument[bool]:
     """
@@ -192,9 +192,10 @@ def load_idf(  # type: ignore[misc]  # overload implementation
     Args:
         path: Path to the IDF file
         version: Optional version override (major, minor, patch)
-        strict: If True, fail fast on malformed IDF objects (default: True)
-        strict_fields: When ``True``, accessing an unknown field name on any
-            IDFObject raises ``AttributeError`` instead of returning ``None``.
+        strict_parsing: If True, fail fast on malformed IDF objects (default: True)
+        strict: When ``True``, accessing or setting an unknown field name on any
+            IDFObject raises :class:`~idfkit.exceptions.InvalidFieldError` instead
+            of returning ``None``.
         preserve_formatting: When ``True``, build a Concrete Syntax Tree
             (CST) so that :func:`write_idf` reproduces the original
             formatting, comments, and whitespace for unmodified objects.
@@ -232,8 +233,8 @@ def load_idf(  # type: ignore[misc]  # overload implementation
     return parse_idf(
         Path(path),
         version=version,
+        strict_parsing=strict_parsing,
         strict=strict,
-        strict_fields=strict_fields,
         preserve_formatting=preserve_formatting,
     )
 
@@ -243,7 +244,7 @@ def load_epjson(
     path: str,
     version: tuple[int, int, int] | None = ...,
     *,
-    strict_fields: Literal[True],
+    strict: Literal[True],
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[True]]: ...
 
@@ -253,7 +254,7 @@ def load_epjson(
     path: str,
     version: tuple[int, int, int] | None = ...,
     *,
-    strict_fields: Literal[False] = ...,
+    strict: Literal[False] = ...,
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[False]]: ...
 
@@ -262,7 +263,7 @@ def load_epjson(  # type: ignore[misc]  # overload implementation
     path: str,
     version: tuple[int, int, int] | None = None,
     *,
-    strict_fields: bool = False,
+    strict: bool = False,
     preserve_formatting: bool = False,
 ) -> IDFDocument[bool]:
     """
@@ -271,8 +272,9 @@ def load_epjson(  # type: ignore[misc]  # overload implementation
     Args:
         path: Path to the epJSON file
         version: Optional version override (major, minor, patch)
-        strict_fields: When ``True``, accessing an unknown field name on any
-            IDFObject raises ``AttributeError`` instead of returning ``None``.
+        strict: When ``True``, accessing or setting an unknown field name on any
+            IDFObject raises :class:`~idfkit.exceptions.InvalidFieldError` instead
+            of returning ``None``.
         preserve_formatting: When ``True``, store the raw JSON text so
             that :func:`write_epjson` can reproduce it byte-for-byte
             when no objects have been modified.
@@ -299,9 +301,7 @@ def load_epjson(  # type: ignore[misc]  # overload implementation
 
     if version is not None:
         _check_version(version)
-    return parse_epjson(
-        Path(path), version=version, strict_fields=strict_fields, preserve_formatting=preserve_formatting
-    )
+    return parse_epjson(Path(path), version=version, strict=strict, preserve_formatting=preserve_formatting)
 
 
 @overload

--- a/src/idfkit/_compat_object.py
+++ b/src/idfkit/_compat_object.py
@@ -262,7 +262,7 @@ class EppyObjectMixin:
             return None
 
         python_key = to_python_name(field_name)
-        ref_name = getattr(self, python_key)
+        ref_name = getattr(self, python_key, None)
         if not ref_name or not isinstance(ref_name, str):
             return None
 

--- a/src/idfkit/document.py
+++ b/src/idfkit/document.py
@@ -141,9 +141,9 @@ class IDFDocument(EppyDocumentMixin, Generic[Strict]):
             version: EnergyPlus version tuple
             schema: EpJSONSchema for validation
             filepath: Source file path
-            strict: When ``True``, accessing an unknown field name on any
+            strict: When ``True``, accessing or setting an unknown field name on any
                 [IDFObject][idfkit.objects.IDFObject] owned by this document raises
-                ``AttributeError`` instead of returning ``None``.  This
+                :class:`~idfkit.exceptions.InvalidFieldError` instead of returning ``None``.  This
                 is useful during migration from eppy to catch field-name
                 typos early.  This value is immutable after construction.
         """
@@ -161,8 +161,8 @@ class IDFDocument(EppyDocumentMixin, Generic[Strict]):
     def strict(self) -> bool:
         """Whether strict field access mode is enabled.
 
-        When ``True``, accessing an unknown field name on objects in this
-        document raises ``AttributeError`` instead of returning ``None``.
+        When ``True``, accessing or setting an unknown field name on objects in this
+        document raises :class:`~idfkit.exceptions.InvalidFieldError` instead of returning ``None``.
 
         This property is read-only; set it via the constructor.
         """

--- a/src/idfkit/epjson_parser.py
+++ b/src/idfkit/epjson_parser.py
@@ -27,7 +27,7 @@ def parse_epjson(
     filepath: Path | str,
     schema: EpJSONSchema | None = None,
     version: tuple[int, int, int] | None = None,
-    strict_fields: bool = False,
+    strict: bool = False,
     *,
     preserve_formatting: bool = False,
 ) -> IDFDocument:
@@ -38,6 +38,9 @@ def parse_epjson(
         filepath: Path to the epJSON file
         schema: Optional EpJSONSchema for validation
         version: Optional version override (auto-detected if not provided)
+        strict: When ``True``, accessing or setting an unknown field name on any
+            IDFObject raises :class:`~idfkit.exceptions.InvalidFieldError` instead
+            of returning ``None``.
         preserve_formatting: If ``True``, store the raw JSON text so that
             :func:`~idfkit.writers.write_epjson` can reproduce it
             byte-for-byte when no objects have been modified.
@@ -66,7 +69,7 @@ def parse_epjson(
         raise FileNotFoundError(f"epJSON file not found: {filepath}")  # noqa: TRY003
 
     parser = EpJSONParser(filepath, schema)
-    return parser.parse(version, strict_fields=strict_fields, preserve_formatting=preserve_formatting)
+    return parser.parse(version, strict=strict, preserve_formatting=preserve_formatting)
 
 
 class EpJSONParser:
@@ -91,7 +94,7 @@ class EpJSONParser:
         self,
         version: tuple[int, int, int] | None = None,
         *,
-        strict_fields: bool = False,
+        strict: bool = False,
         preserve_formatting: bool = False,
     ) -> IDFDocument:
         """
@@ -99,7 +102,7 @@ class EpJSONParser:
 
         Args:
             version: Optional version override
-            strict_fields: Enforce strict field access on the resulting document.
+            strict: Enforce strict field access on the resulting document.
             preserve_formatting: Store raw JSON text for lossless round-tripping.
 
         Returns:
@@ -126,7 +129,7 @@ class EpJSONParser:
             schema = get_schema(version)
 
         # Create document
-        doc = IDFDocument(version=version, schema=schema, filepath=self._filepath, strict=strict_fields)  # type: ignore[reportCallIssue]  # .pyi uses covariant Strict
+        doc = IDFDocument(version=version, schema=schema, filepath=self._filepath, strict=strict)  # type: ignore[reportCallIssue]  # .pyi uses covariant Strict
 
         # Parse objects
         self._parse_objects(data, doc, schema)

--- a/src/idfkit/idf_parser.py
+++ b/src/idfkit/idf_parser.py
@@ -96,8 +96,8 @@ def parse_idf(
     schema: EpJSONSchema | None = None,
     version: tuple[int, int, int] | None = None,
     encoding: str = "latin-1",
-    strict: bool = True,
-    strict_fields: bool = False,
+    strict_parsing: bool = True,
+    strict: bool = False,
     *,
     preserve_formatting: bool = False,
 ) -> IDFDocument:
@@ -109,7 +109,10 @@ def parse_idf(
         schema: Optional EpJSONSchema for field ordering and type coercion
         version: Optional version override (auto-detected if not provided)
         encoding: File encoding (default: latin-1 for compatibility)
-        strict: If True, fail fast on malformed objects (default: True)
+        strict_parsing: If True, fail fast on malformed objects (default: True)
+        strict: When ``True``, accessing or setting an unknown field name on any
+            IDFObject raises :class:`~idfkit.exceptions.InvalidFieldError` instead
+            of returning ``None``.
         preserve_formatting: If ``True``, build a Concrete Syntax Tree (CST)
             so that writing the document back preserves original formatting,
             comments, and whitespace for unmodified objects.  The default
@@ -152,8 +155,8 @@ def parse_idf(
     if not filepath.exists():
         raise FileNotFoundError(f"IDF file not found: {filepath}")  # noqa: TRY003
 
-    parser = IDFParser(filepath, schema, encoding, strict=strict)
-    return parser.parse(version, strict_fields=strict_fields, preserve_formatting=preserve_formatting)
+    parser = IDFParser(filepath, schema, encoding, strict_parsing=strict_parsing)
+    return parser.parse(version, strict=strict, preserve_formatting=preserve_formatting)
 
 
 class IDFParser:
@@ -163,32 +166,32 @@ class IDFParser:
     Uses memory mapping for large files and regex for tokenization.
     """
 
-    __slots__ = ("_content", "_encoding", "_filepath", "_schema", "_strict")
+    __slots__ = ("_content", "_encoding", "_filepath", "_schema", "_strict_parsing")
 
     _filepath: Path
     _schema: EpJSONSchema | None
     _encoding: str
     _content: bytes | None
-    _strict: bool
+    _strict_parsing: bool
 
     def __init__(
         self,
         filepath: Path,
         schema: EpJSONSchema | None = None,
         encoding: str = "latin-1",
-        strict: bool = True,
+        strict_parsing: bool = True,
     ):
         self._filepath = filepath
         self._schema = schema
         self._encoding = encoding
-        self._strict = strict
+        self._strict_parsing = strict_parsing
         self._content: bytes | None = None
 
     def parse(
         self,
         version: tuple[int, int, int] | None = None,
         *,
-        strict_fields: bool = False,
+        strict: bool = False,
         preserve_formatting: bool = False,
     ) -> IDFDocument:
         """
@@ -196,7 +199,7 @@ class IDFParser:
 
         Args:
             version: Optional version override
-            strict_fields: Enforce strict field access on the resulting document.
+            strict: Enforce strict field access on the resulting document.
             preserve_formatting: Build a CST for lossless round-tripping.
 
         Returns:
@@ -221,7 +224,7 @@ class IDFParser:
             schema = get_schema(version)
 
         # Create document
-        doc = IDFDocument(version=version, schema=schema, filepath=self._filepath, strict=strict_fields)  # type: ignore[reportCallIssue]  # .pyi uses covariant Strict
+        doc = IDFDocument(version=version, schema=schema, filepath=self._filepath, strict=strict)  # type: ignore[reportCallIssue]  # .pyi uses covariant Strict
 
         # Parse objects
         self._parse_objects(content, doc, schema)
@@ -325,7 +328,7 @@ class IDFParser:
             except IDFParseError:
                 raise
             except Exception as exc:
-                if self._strict:
+                if self._strict_parsing:
                     self._raise_parse_error(
                         content,
                         match_offset,
@@ -402,7 +405,7 @@ class IDFParser:
                 else:
                     data[field_name] = ""
 
-        if not pc.extensible and len(remaining_fields) > num_named and self._strict:
+        if not pc.extensible and len(remaining_fields) > num_named and self._strict_parsing:
             overflow = len(remaining_fields) - num_named
             msg = (
                 f"Object has {overflow} extra field(s) but type is not extensible "
@@ -434,7 +437,7 @@ class IDFParser:
         """Append extensible field groups to parsed data."""
         ext_size = pc.ext_size
         if ext_size <= 0:
-            if self._strict:
+            if self._strict_parsing:
                 msg = "Object is marked extensible but extensible group size is invalid"
                 raise ValueError(msg)
             return
@@ -559,7 +562,7 @@ class IDFParser:
                 canonical_cache[obj_type] = canonical
             return (pc, False, canonical)
 
-        if self._strict:
+        if self._strict_parsing:
             msg = f"Unknown object type '{obj_type}'"
             self._raise_parse_error(content, match_offset, msg, obj_type=obj_type, obj_name=obj_name)
         skipped_types.add(obj_type)

--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from ._compat_object import EppyObjectMixin
+from .exceptions import InvalidFieldError
 
 if TYPE_CHECKING:
     from .document import IDFDocument
@@ -201,9 +202,12 @@ class IDFObject(EppyObjectMixin):
             field_order = object.__getattribute__(self, "_field_order")
             if field_order is not None and python_key not in field_order:
                 obj_type = object.__getattribute__(self, "_type")
-                raise AttributeError(  # noqa: TRY003
-                    f"'{obj_type}' object has no field '{key}'. "
-                    f"Known fields: {', '.join(field_order[:10])}{'...' if len(field_order) > 10 else ''}"
+                ver: tuple[int, int, int] | None = object.__getattribute__(doc, "version")
+                raise InvalidFieldError(
+                    obj_type,
+                    key,
+                    available_fields=list(field_order),
+                    version=ver,
                 )
 
         # Default: return None (eppy behaviour)
@@ -218,6 +222,18 @@ class IDFObject(EppyObjectMixin):
         else:
             # Normalize key to python style
             python_key = to_python_name(key)
+            # Validate in strict mode
+            doc = self._document
+            if doc is not None and getattr(doc, "_strict", False):
+                field_order = self._field_order
+                if field_order is not None and python_key not in field_order:
+                    ver: tuple[int, int, int] | None = object.__getattribute__(doc, "version")
+                    raise InvalidFieldError(
+                        self._type,
+                        key,
+                        available_fields=list(field_order),
+                        version=ver,
+                    )
             self._set_field(python_key, value)
 
     def __getitem__(self, key: str | int) -> Any:

--- a/tests/test_eppy_compat.py
+++ b/tests/test_eppy_compat.py
@@ -851,7 +851,7 @@ class TestStrictFieldAccess:
     def test_strict_raises_on_unknown_field(self) -> None:
         doc = new_document(version=(24, 1, 0), strict=True)
         zone = doc.add("Zone", "Office")
-        with pytest.raises(AttributeError, match="no field"):
+        with pytest.raises(AttributeError, match="Invalid field"):
             _ = zone.x_orgin  # intentional typo
 
     def test_strict_allows_known_field(self) -> None:

--- a/tests/test_idf_roundtrip.py
+++ b/tests/test_idf_roundtrip.py
@@ -435,7 +435,7 @@ CONSTRUCTION,
         idf_path = tmp_path / "caps.idf"
         idf_path.write_text(idf_content)
 
-        doc = parse_idf(idf_path, strict=True)
+        doc = parse_idf(idf_path, strict_parsing=True)
 
         # Objects should be accessible under canonical PascalCase names
         assert doc["Zone"]["TestZone"] is not None
@@ -463,7 +463,7 @@ SCHEDULE:COMPACT,
         idf_path = tmp_path / "schedule.idf"
         idf_path.write_text(idf_content)
 
-        doc = parse_idf(idf_path, strict=True)
+        doc = parse_idf(idf_path, strict_parsing=True)
 
         assert doc["Schedule:Compact"]["TestSchedule"] is not None
 
@@ -473,7 +473,7 @@ SCHEDULE:COMPACT,
         idf_path = tmp_path / "caps.idf"
         idf_path.write_text(idf_content)
 
-        doc = parse_idf(idf_path, strict=True)
+        doc = parse_idf(idf_path, strict_parsing=True)
 
         # The collection key should be canonical "Zone", not "ZONE"
         assert "Zone" in doc.collections
@@ -496,7 +496,7 @@ zone,
         idf_path = tmp_path / "mixed.idf"
         idf_path.write_text(idf_content)
 
-        doc = parse_idf(idf_path, strict=True)
+        doc = parse_idf(idf_path, strict_parsing=True)
 
         # All three should be in the canonical "Zone" collection
         assert len(doc["Zone"]) == 3
@@ -510,7 +510,7 @@ zone,
         idf_path = tmp_path / "noschema.idf"
         idf_path.write_text(idf_content)
 
-        doc = parse_idf(idf_path, schema=None, version=(24, 1, 0), strict=False)
+        doc = parse_idf(idf_path, schema=None, version=(24, 1, 0), strict_parsing=False)
 
         # schema=None triggers auto-load from version, so normalization still applies
         assert "Zone" in doc.collections

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -376,7 +376,7 @@ TotallyMadeUpObject, Foo;
         filepath = tmp_path / "bad_bytes.idf"
         filepath.write_bytes(content)
 
-        doc = parse_idf(filepath, encoding="utf-8", strict=False)
+        doc = parse_idf(filepath, encoding="utf-8", strict_parsing=False)
         assert len(doc["Zone"]) == 0
 
     def test_invalid_field_bytes_strict_true_wrapped(self, tmp_path: Path) -> None:
@@ -386,6 +386,6 @@ TotallyMadeUpObject, Foo;
         filepath.write_bytes(content)
 
         with pytest.raises(IDFParseError, match="Failed to parse object") as exc_info:
-            parse_idf(filepath, encoding="utf-8", strict=True)
+            parse_idf(filepath, encoding="utf-8", strict_parsing=True)
         assert exc_info.value.diagnostics
         assert exc_info.value.diagnostics[0].obj_type == "Zone"

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -351,7 +351,7 @@ Material,
         idf_path = tmp_path / "input.idf"
         idf_path.write_text(idf_content)
 
-        doc = parse_idf(idf_path, strict=False, preserve_formatting=True)
+        doc = parse_idf(idf_path, strict_parsing=False, preserve_formatting=True)
 
         # CST is preserved; known objects are linked, unknown node is unlinked.
         assert doc.cst is not None

--- a/tests/test_strict_typing.py
+++ b/tests/test_strict_typing.py
@@ -182,8 +182,8 @@ class TestStubGeneration:
         assert "str" in result
 
 
-class TestLoadIdfStrictFields:
-    """Test that load_idf's strict_fields parameter works."""
+class TestLoadIdfStrict:
+    """Test that load_idf's strict parameter works."""
 
     def test_load_idf_default_non_strict(self, tmp_path: Path) -> None:
         from idfkit import load_idf, write_idf
@@ -196,19 +196,19 @@ class TestLoadIdfStrictFields:
         loaded = load_idf(str(path))
         assert loaded.strict is False
 
-    def test_load_idf_strict_fields(self, tmp_path: Path) -> None:
+    def test_load_idf_strict_true(self, tmp_path: Path) -> None:
         from idfkit import load_idf, write_idf
 
         doc = new_document()
         path = tmp_path / "test.idf"
         write_idf(doc, str(path))
 
-        loaded = load_idf(str(path), strict_fields=True)
+        loaded = load_idf(str(path), strict=True)
         assert loaded.strict is True
 
 
-class TestLoadEpjsonStrictFields:
-    """Test that load_epjson's strict_fields parameter works."""
+class TestLoadEpjsonStrict:
+    """Test that load_epjson's strict parameter works."""
 
     def test_load_epjson_default_non_strict(self, tmp_path: Path) -> None:
         from idfkit import load_epjson, write_epjson
@@ -220,14 +220,14 @@ class TestLoadEpjsonStrictFields:
         loaded = load_epjson(str(path))
         assert loaded.strict is False
 
-    def test_load_epjson_strict_fields(self, tmp_path: Path) -> None:
+    def test_load_epjson_strict_true(self, tmp_path: Path) -> None:
         from idfkit import load_epjson, write_epjson
 
         doc = new_document()
         path = tmp_path / "test.epJSON"
         write_epjson(doc, str(path))
 
-        loaded = load_epjson(str(path), strict_fields=True)
+        loaded = load_epjson(str(path), strict=True)
         assert loaded.strict is True
 
 


### PR DESCRIPTION
## Summary
**BREAKING**: Rename parameters across the public API for clarity:
- `load_idf`: `strict` → `strict_parsing`, `strict_fields` → `strict`
- `load_epjson`: `strict_fields` → `strict`
- `parse_idf` / `parse_epjson`: same renames

Also:
- `IDFObject.__getattr__` raises `InvalidFieldError` (not raw `AttributeError`) in strict mode
- `IDFObject.__setattr__` validates field names in strict mode
- `_compat_object.py` uses `getattr` default to avoid strict mode errors

Replaces #87. Defaults unchanged (`strict=False` for field access).

## Test plan
- [x] `make check` passes
- [x] `make test` passes (1960 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)