### PR TITLE
Make strict field access the default

### DIFF
--- a/docs/concepts/type-safety.md
+++ b/docs/concepts/type-safety.md
@@ -23,8 +23,8 @@ For example, hovering over `zone.ceiling_height` in your IDE will show:
 
 ## Strict Field Access
 
-By default, accessing a misspelled field name returns `None`. Enable **strict
-mode** to catch typos at runtime with an `AttributeError`:
+By default, accessing a misspelled field name raises an `InvalidFieldError`.
+Disable **strict mode** to fall back to returning `None` for unknown fields:
 
 ```python
 --8<-- "docs/snippets/concepts/type-safety/strict_fields.py:example"
@@ -32,12 +32,12 @@ mode** to catch typos at runtime with an `AttributeError`:
 
 | Function | Parameter |
 |----------|-----------|
-| `new_document()` | `strict=True` |
-| `load_idf()` | `strict=True` |
-| `load_epjson()` | `strict=True` |
+| `new_document()` | `strict=True` (default) |
+| `load_idf()` | `strict=True` (default) |
+| `load_epjson()` | `strict=True` (default) |
 
 !!! tip
-    Strict mode is recommended during development. Disable it when loading
+    Strict mode is on by default. Disable it with `strict=False` when loading
     third-party IDF files that may contain non-standard fields.
 
 ## Dynamic Key Access

--- a/docs/idfkit-dev-guide.md
+++ b/docs/idfkit-dev-guide.md
@@ -198,7 +198,7 @@ intersect_match(doc)
 - **Snake-case fields**: Use `zone.x_origin`, not `zone["X Origin"]` (both work, attributes preferred).
 - **Validation is opt-in**: Call `validate_document()` explicitly; parsing does not validate.
 - **Rename cascades**: `doc.rename()` updates all cross-references automatically.
-- **Strict mode**: `doc.strict = True` raises `AttributeError` on field typos (useful for debugging).
+- **Strict mode**: Strict field access is on by default; raises `InvalidFieldError` on field typos. Disable with `strict=False`.
 - **Optional extras**: Core features (simulation, schedules, thermal, geometry) need no extras. Install `idfkit[weather]` for index refresh, `idfkit[pandas]` for DataFrames, `idfkit[plot]`/`idfkit[plotly]` for plotting, `idfkit[progress]` for tqdm bars, `idfkit[s3]` for cloud storage, or `idfkit[all]`.
 
 ### Exception Hierarchy

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -284,21 +284,18 @@ idfkit has two different strictness settings:
 - **Strict parsing** (`load_idf(..., strict_parsing=True)`) validates IDF input while
   reading and is enabled by default.
 - **Strict field access** (`load_idf(..., strict=True)`) raises on mistyped attribute
-  names when reading or writing object fields.
+  names when reading or writing object fields. This is on by default.
 
 eppy silently returns an empty string when you mistype a field name,
-making bugs hard to find. idfkit defaults to the same behaviour for
-compatibility at field-access time, but you can opt in to **strict field
-access** to catch typos
-immediately:
+making bugs hard to find. idfkit enables **strict field access** by
+default to catch typos immediately:
 
 ```python
 --8<-- "docs/snippets/migration/strict_mode.py:example"
 ```
 
-Enable strict field access during migration to surface field-name
-mismatches early. Once your code is clean you can leave it on or turn it
-off.
+Strict field access is on by default. Disable it with `strict=False`
+when loading third-party IDF files that may contain non-standard fields.
 
 ## Running a simulation
 

--- a/docs/snippets/concepts/type-safety/strict_fields.py
+++ b/docs/snippets/concepts/type-safety/strict_fields.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 # --8<-- [start:example]
 from idfkit import new_document
 
-# Enable strict field access on a new document
-doc = new_document(strict=True)
+# Strict field access is on by default
+doc = new_document()
 
 zone = doc.add("Zone", "Office")
 zone.x_origin = 0.0  # OK — valid field
 
-# zone.x_orgin = 0.0  # AttributeError! Typo caught immediately
+# zone.x_orgin = 0.0  # InvalidFieldError! Typo caught immediately
 
-# Also available when loading files
-# model = load_idf("building.idf", strict=True)
-# model = load_epjson("building.epJSON", strict=True)
+# Also the default when loading files
+# model = load_idf("building.idf")
+# model = load_epjson("building.epJSON")
 # --8<-- [end:example]

--- a/docs/snippets/migration/strict_mode.py
+++ b/docs/snippets/migration/strict_mode.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 # --8<-- [start:example]
 from idfkit import new_document
 
-# Enable strict mode to catch field-name typos during migration
-doc = new_document(strict=True)
+# Strict field access is on by default
+doc = new_document()
 
 zone = doc.add("Zone", "Office", x_origin=5.0)
 print(zone.x_origin)  # 5.0 — known field, works fine
 
-zone.x_orgin  # AttributeError: 'Zone' object has no field 'x_orgin'
+zone.x_orgin  # InvalidFieldError: 'Zone' object has no field 'x_orgin'
 # --8<-- [end:example]

--- a/src/idfkit/__init__.py
+++ b/src/idfkit/__init__.py
@@ -162,7 +162,7 @@ def load_idf(
     version: tuple[int, int, int] | None = ...,
     *,
     strict_parsing: bool = ...,
-    strict: Literal[True],
+    strict: Literal[True] = ...,
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[True]]: ...
 
@@ -173,7 +173,7 @@ def load_idf(
     version: tuple[int, int, int] | None = ...,
     *,
     strict_parsing: bool = ...,
-    strict: Literal[False] = ...,
+    strict: Literal[False],
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[False]]: ...
 
@@ -183,7 +183,7 @@ def load_idf(  # type: ignore[misc]  # overload implementation
     version: tuple[int, int, int] | None = None,
     *,
     strict_parsing: bool = True,
-    strict: bool = False,
+    strict: bool = True,
     preserve_formatting: bool = False,
 ) -> IDFDocument[bool]:
     """
@@ -244,7 +244,7 @@ def load_epjson(
     path: str,
     version: tuple[int, int, int] | None = ...,
     *,
-    strict: Literal[True],
+    strict: Literal[True] = ...,
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[True]]: ...
 
@@ -254,7 +254,7 @@ def load_epjson(
     path: str,
     version: tuple[int, int, int] | None = ...,
     *,
-    strict: Literal[False] = ...,
+    strict: Literal[False],
     preserve_formatting: bool = ...,
 ) -> IDFDocument[Literal[False]]: ...
 
@@ -263,7 +263,7 @@ def load_epjson(  # type: ignore[misc]  # overload implementation
     path: str,
     version: tuple[int, int, int] | None = None,
     *,
-    strict: bool = False,
+    strict: bool = True,
     preserve_formatting: bool = False,
 ) -> IDFDocument[bool]:
     """
@@ -308,7 +308,7 @@ def load_epjson(  # type: ignore[misc]  # overload implementation
 def new_document(
     version: tuple[int, int, int] = ...,
     *,
-    strict: Literal[True],
+    strict: Literal[True] = ...,
 ) -> IDFDocument[Literal[True]]: ...
 
 
@@ -316,22 +316,23 @@ def new_document(
 def new_document(
     version: tuple[int, int, int] = ...,
     *,
-    strict: Literal[False] = ...,
+    strict: Literal[False],
 ) -> IDFDocument[Literal[False]]: ...
 
 
 def new_document(  # type: ignore[misc]  # overload implementation
     version: tuple[int, int, int] = LATEST_VERSION,
     *,
-    strict: bool = False,
+    strict: bool = True,
 ) -> IDFDocument[bool]:
     """
     Create a new IDFDocument with baseline singleton objects populated.
 
     Args:
         version: EnergyPlus version (default: latest supported version)
-        strict: When ``True``, accessing an unknown field name on any
-            IDFObject raises ``AttributeError`` instead of returning ``None``.
+        strict: When ``True``, accessing or setting an unknown field name on any
+            IDFObject raises :class:`~idfkit.exceptions.InvalidFieldError` instead
+            of returning ``None``.
 
     Returns:
         IDFDocument with schema loaded and baseline objects seeded

--- a/src/idfkit/document.py
+++ b/src/idfkit/document.py
@@ -132,7 +132,7 @@ class IDFDocument(EppyDocumentMixin, Generic[Strict]):
         schema: EpJSONSchema | None = None,
         filepath: Path | str | None = None,
         *,
-        strict: bool = False,
+        strict: bool = True,
     ) -> None:
         """
         Initialize an IDFDocument.

--- a/src/idfkit/epjson_parser.py
+++ b/src/idfkit/epjson_parser.py
@@ -27,7 +27,7 @@ def parse_epjson(
     filepath: Path | str,
     schema: EpJSONSchema | None = None,
     version: tuple[int, int, int] | None = None,
-    strict: bool = False,
+    strict: bool = True,
     *,
     preserve_formatting: bool = False,
 ) -> IDFDocument:
@@ -94,7 +94,7 @@ class EpJSONParser:
         self,
         version: tuple[int, int, int] | None = None,
         *,
-        strict: bool = False,
+        strict: bool = True,
         preserve_formatting: bool = False,
     ) -> IDFDocument:
         """

--- a/src/idfkit/idf_parser.py
+++ b/src/idfkit/idf_parser.py
@@ -97,7 +97,7 @@ def parse_idf(
     version: tuple[int, int, int] | None = None,
     encoding: str = "latin-1",
     strict_parsing: bool = True,
-    strict: bool = False,
+    strict: bool = True,
     *,
     preserve_formatting: bool = False,
 ) -> IDFDocument:
@@ -191,7 +191,7 @@ class IDFParser:
         self,
         version: tuple[int, int, int] | None = None,
         *,
-        strict: bool = False,
+        strict: bool = True,
         preserve_formatting: bool = False,
     ) -> IDFDocument:
         """

--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
 # Field name conversion patterns
 _FIELD_NAME_PATTERN = re.compile(r"[^a-zA-Z0-9]+")
 
+# Matches a numbered extensible field like "vertex_1_x_coordinate" -> "vertex_x_coordinate"
+_EXTENSIBLE_NUMBER_PATTERN = re.compile(r"^(.+?)_(\d+)_(.+)$")
+
 
 def to_python_name(idf_name: str) -> str:
     """Convert IDF field name to Python-friendly name.
@@ -159,6 +162,34 @@ class IDFObject(EppyObjectMixin):
         """Ordered list of field names from schema."""
         return self._field_order
 
+    def _is_known_field(self, python_key: str, field_order: list[str]) -> bool:
+        """Check if a field name is valid for this object type.
+
+        Checks the base field order first, then extensible field patterns.
+        Handles both ``vertex_1_x_coordinate`` -> ``vertex_x_coordinate``
+        and ``field_1`` -> ``field``.
+        """
+        if python_key in field_order:
+            return True
+        schema = self._schema
+        if schema is None:
+            return False
+        legacy: dict[str, Any] = schema.get("legacy_idd", {})
+        extensibles: list[str] = legacy.get("extensibles", [])
+        if not extensibles:
+            return False
+        # Try "prefix_N_suffix" -> "prefix_suffix" (e.g. vertex_1_x_coordinate -> vertex_x_coordinate)
+        m = _EXTENSIBLE_NUMBER_PATTERN.match(python_key)
+        if m and f"{m.group(1)}_{m.group(3)}" in extensibles:
+            return True
+        # Try "base_N" -> "base" (e.g. field_1461 -> field)
+        last_underscore = python_key.rfind("_")
+        if last_underscore > 0 and python_key[last_underscore + 1 :].isdigit():
+            base = python_key[:last_underscore]
+            if base in extensibles:
+                return True
+        return False
+
     @property
     def name(self) -> str:
         """The object's name."""
@@ -200,7 +231,7 @@ class IDFObject(EppyObjectMixin):
         if doc is not None and getattr(doc, "_strict", False):
             # In strict mode, only allow known schema fields
             field_order = object.__getattribute__(self, "_field_order")
-            if field_order is not None and python_key not in field_order:
+            if field_order is not None and not self._is_known_field(python_key, field_order):
                 obj_type = object.__getattribute__(self, "_type")
                 ver: tuple[int, int, int] | None = object.__getattribute__(doc, "version")
                 raise InvalidFieldError(
@@ -226,7 +257,7 @@ class IDFObject(EppyObjectMixin):
             doc = self._document
             if doc is not None and getattr(doc, "_strict", False):
                 field_order = self._field_order
-                if field_order is not None and python_key not in field_order:
+                if field_order is not None and not self._is_known_field(python_key, field_order):
                     ver: tuple[int, int, int] | None = object.__getattribute__(doc, "version")
                     raise InvalidFieldError(
                         self._type,

--- a/tests/test_eppy_compat.py
+++ b/tests/test_eppy_compat.py
@@ -860,7 +860,7 @@ class TestStrictFieldAccess:
         assert zone.x_origin == 5.0
 
     def test_non_strict_returns_none_for_unknown(self) -> None:
-        doc = new_document(version=(24, 1, 0))
+        doc = new_document(version=(24, 1, 0), strict=False)
         zone = doc.add("Zone", "Office")
         assert zone.x_orgin is None  # typo returns None
 

--- a/tests/test_strict_typing.py
+++ b/tests/test_strict_typing.py
@@ -14,9 +14,9 @@ from idfkit.objects import IDFCollection
 class TestIDFDocumentStrict:
     """Test IDFDocument's strict (read-only) property and Generic[Strict] behavior."""
 
-    def test_strict_default_false(self) -> None:
+    def test_strict_default_true(self) -> None:
         doc = new_document()
-        assert doc.strict is False
+        assert doc.strict is True
 
     def test_strict_true(self) -> None:
         doc = new_document(strict=True)
@@ -185,7 +185,7 @@ class TestStubGeneration:
 class TestLoadIdfStrict:
     """Test that load_idf's strict parameter works."""
 
-    def test_load_idf_default_non_strict(self, tmp_path: Path) -> None:
+    def test_load_idf_default_strict(self, tmp_path: Path) -> None:
         from idfkit import load_idf, write_idf
 
         # Create a minimal IDF file
@@ -194,23 +194,23 @@ class TestLoadIdfStrict:
         write_idf(doc, str(path))
 
         loaded = load_idf(str(path))
-        assert loaded.strict is False
+        assert loaded.strict is True
 
-    def test_load_idf_strict_true(self, tmp_path: Path) -> None:
+    def test_load_idf_strict_false(self, tmp_path: Path) -> None:
         from idfkit import load_idf, write_idf
 
         doc = new_document()
         path = tmp_path / "test.idf"
         write_idf(doc, str(path))
 
-        loaded = load_idf(str(path), strict=True)
-        assert loaded.strict is True
+        loaded = load_idf(str(path), strict=False)
+        assert loaded.strict is False
 
 
 class TestLoadEpjsonStrict:
     """Test that load_epjson's strict parameter works."""
 
-    def test_load_epjson_default_non_strict(self, tmp_path: Path) -> None:
+    def test_load_epjson_default_strict(self, tmp_path: Path) -> None:
         from idfkit import load_epjson, write_epjson
 
         doc = new_document()
@@ -218,17 +218,17 @@ class TestLoadEpjsonStrict:
         write_epjson(doc, str(path))
 
         loaded = load_epjson(str(path))
-        assert loaded.strict is False
+        assert loaded.strict is True
 
-    def test_load_epjson_strict_true(self, tmp_path: Path) -> None:
+    def test_load_epjson_strict_false(self, tmp_path: Path) -> None:
         from idfkit import load_epjson, write_epjson
 
         doc = new_document()
         path = tmp_path / "test.epJSON"
         write_epjson(doc, str(path))
 
-        loaded = load_epjson(str(path), strict=True)
-        assert loaded.strict is True
+        loaded = load_epjson(str(path), strict=False)
+        assert loaded.strict is False
 
 
 class TestStubRuntimeConsistency:


### PR DESCRIPTION
## Summary
**BREAKING**: All entry points now default to `strict=True`:
- `new_document()`, `load_idf()`, `load_epjson()` validate field names on access and assignment by default
- Accessing or setting an unknown field raises `InvalidFieldError` instead of returning `None`
- Pass `strict=False` to restore the old permissive behavior

Also adds extensible field validation:
- `_is_known_field()` correctly handles extensible patterns like `vertex_1_x_coordinate` and `field_1461`

Replaces #88. This is the final PR for v0.6.0.

## Test plan
- [x] `make check` passes
- [x] `make test` passes (1960 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)