### PR TITLE
Fix PR preview site_url for correct asset paths

### DIFF
--- a/.github/workflows/deploy-pr-docs.yml
+++ b/.github/workflows/deploy-pr-docs.yml
@@ -35,7 +35,10 @@ jobs:
           sudo apt-get install -y libcairo2
 
       - name: Build documentation
-        run: ./scripts/build_docs.sh
+        run: |
+          PREVIEW_URL="https://py.idfkit.com/pr-preview/pr-${{ github.event.number }}/"
+          sed -i "s|^site_url:.*|site_url: ${PREVIEW_URL}|" mkdocs.yml
+          ./scripts/build_docs.sh
 
       - name: Fetch base branch for diff
         run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1


### PR DESCRIPTION
## Summary
- Override `site_url` in PR preview builds so CSS, JS, and navigation links resolve correctly under `/pr-preview/pr-N/` instead of the root site path
- Same fix applied to idfkit-mcp in idfkit/idfkit-mcp#34

## Test plan
- [ ] Open a PR with doc changes and verify the preview renders with working CSS/JS/navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)