### PR TITLE
Restrict public API surface of objects module

### DIFF
--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from ._compat_object import EppyObjectMixin
 from .exceptions import InvalidFieldError
 
+__all__ = ["IDFCollection", "IDFObject", "to_python_name"]
+
 if TYPE_CHECKING:
     from .document import IDFDocument
 


### PR DESCRIPTION
## Summary
- Add `__all__` to `objects.py` to explicitly mark `IDFCollection`, `IDFObject`, and `to_python_name` as public
- Excludes internal extensible field helpers (`parse_extensible_index`, `extensible_schema_name`, `normalize_extensible_name`) from the public API without using `_` prefix (which would trigger pyright `reportPrivateUsage` for cross-module usage within the package)

## Test plan
- [x] `make check` passes (no new errors)
- [x] `make test` passes (1964 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)