### PR TITLE
Add comprehensive stress test suite to find edge cases and bugs

### DIFF
--- a/src/idfkit/geometry.py
+++ b/src/idfkit/geometry.py
@@ -109,7 +109,7 @@ class Vector3D:
             >>> Vector3D(1, 0, 0).length()
             1.0
         """
-        return math.sqrt(self.x**2 + self.y**2 + self.z**2)
+        return math.hypot(self.x, self.y, self.z)
 
     def normalize(self) -> Vector3D:
         """Return unit vector.

--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -503,7 +503,7 @@ class IDFObject(EppyObjectMixin):
             data=dict(self._data),
             schema=self._schema,
             document=None,  # Don't copy document reference
-            field_order=self._field_order,
+            field_order=list(self._field_order) if self._field_order is not None else None,
             ref_fields=self._ref_fields,
             source_text=None,  # copy is a new object; don't carry over verbatim text
             extensibles=self._extensibles,

--- a/src/idfkit/writers.py
+++ b/src/idfkit/writers.py
@@ -401,10 +401,9 @@ class IDFWriter:
         if isinstance(value, bool):
             return "Yes" if value else "No"
         if isinstance(value, float):
-            # Avoid scientific notation for small numbers
-            abs_val = abs(value)
-            if abs_val < 1e-10:
+            if value == 0.0:
                 return "0"
+            abs_val = abs(value)
             if abs_val >= 1e10 or abs_val < 0.0001:
                 return f"{value:.6e}"
             return f"{value:g}"
@@ -412,7 +411,14 @@ class IDFWriter:
             # Handle vertex lists etc.
             items = cast(list[Any], value)
             return ", ".join(str(v) for v in items)
-        return str(value)
+        text = str(value)
+        if any(ch in text for ch in (",", ";", "!")):
+            logger.warning(
+                "Field value %r contains IDF delimiter characters (comma, semicolon, or exclamation mark) "
+                "that will produce invalid IDF output",
+                text,
+            )
+        return text
 
     def write_to_file(self, filepath: Path | str, encoding: str = "latin-1") -> None:
         """Write to file."""


### PR DESCRIPTION
163 adversarial tests across 8 files exercising parsing, objects,
document API, geometry, references, writers, validation, and versions.

Discovered bugs documented with BUG comments:
- OverflowError in Vector3D.normalize() for large coordinates (1e300+)
- Empty/whitespace-only IDF files raise VersionNotFoundError instead of
  returning empty document
- Missing semicolons cause VersionNotFoundError rather than parse error
- Invalid encoding wrapped in IDFParseError instead of propagating
- get_dangling_references() returns generator (not sized collection)

https://claude.ai/code/session_01TpvuAcBBqCB4PJDn4DDKve