### PR TITLE
Add tests for weather module to improve code coverage

### DIFF
--- a/tests/test_weather_designday.py
+++ b/tests/test_weather_designday.py
@@ -3,12 +3,39 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from idfkit.weather.designday import DesignDayManager, DesignDayType, _classify_design_day
+from idfkit.weather.designday import (
+    DesignDayManager,
+    DesignDayType,
+    _classify_design_day,  # pyright: ignore[reportPrivateUsage]
+    apply_ashrae_sizing,
+)
+from idfkit.weather.station import WeatherStation
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "weather"
+
+
+def _make_station(
+    *,
+    wmo: str = "725300",
+    latitude: float = 41.98,
+    longitude: float = -87.92,
+) -> WeatherStation:
+    return WeatherStation(
+        country="USA",
+        state="IL",
+        city="Chicago.Ohare.Intl.AP",
+        wmo=wmo,
+        source="SRC-TMYx",
+        latitude=latitude,
+        longitude=longitude,
+        timezone=-6.0,
+        elevation=201.0,
+        url="https://example.com/USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.zip",
+    )
 
 
 class TestClassifyDesignDay:
@@ -23,6 +50,9 @@ class TestClassifyDesignDay:
 
     def test_cooling_db_1(self) -> None:
         assert _classify_design_day("Chicago Ohare Intl AP Ann Clg 1% Condns DB=>MWB") == DesignDayType.COOLING_DB_1
+
+    def test_cooling_db_2(self) -> None:
+        assert _classify_design_day("Chicago Ohare Intl AP Ann Clg 2% Condns DB=>MWB") == DesignDayType.COOLING_DB_2
 
     def test_cooling_wb_1(self) -> None:
         assert _classify_design_day("Chicago Ohare Intl AP Ann Clg 1% Condns WB=>MDB") == DesignDayType.COOLING_WB_1
@@ -61,11 +91,16 @@ class TestClassifyDesignDay:
             _classify_design_day("Chicago Ohare Intl AP Ann Htg Wind 99% Condns WS=>MCDB") == DesignDayType.HTG_WIND_99
         )
 
+    def test_wind_04(self) -> None:
+        assert _classify_design_day("Coldest Month WS/MDB 0.4%") == DesignDayType.WIND_0_4
+
+    def test_wind_1(self) -> None:
+        assert _classify_design_day("Coldest Month WS/MDB 1%") == DesignDayType.WIND_1
+
     def test_unknown_returns_none(self) -> None:
         assert _classify_design_day("Some Random Design Day Name") is None
 
     def test_monthly_not_classified(self) -> None:
-        """Monthly design days should not match any annual classification."""
         assert _classify_design_day("Chicago Ohare Intl AP January .4% Condns DB=>MCWB") is None
         assert _classify_design_day("Chicago Ohare Intl AP July .4% Condns WB=>MCDB") is None
 
@@ -73,12 +108,10 @@ class TestClassifyDesignDay:
 class TestDesignDayManager:
     def test_parse_sample_ddy(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
-        # 6 original annual + 1 enthalpy + 1 humidification + 1 htg wind + 2 monthly = 11
         assert len(ddm.all_design_days) == 11
 
     def test_annual_filter(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
-        # 6 original + 1 enthalpy + 1 humidification + 1 htg wind = 9 classified annual
         assert len(ddm.annual) == 9
 
     def test_monthly_filter(self) -> None:
@@ -94,7 +127,6 @@ class TestDesignDayManager:
 
     def test_cooling_filter(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
-        # 2 DB cooling + 1 WB cooling + 1 dehumid + 1 enthalpy = 5 cooling-related
         assert len(ddm.cooling) == 5
 
     def test_location(self) -> None:
@@ -128,13 +160,20 @@ class TestDesignDayManager:
 
     def test_get_missing_type_returns_none(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
-        # WIND types (EnergyPlus "Coldest Month" format) are not in our fixture
         assert ddm.get(DesignDayType.WIND_0_4) is None
 
     def test_empty_ddy(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "empty.ddy")
         assert len(ddm.all_design_days) == 0
         assert ddm.location is not None
+
+    def test_parse_no_location_no_design_days(self, tmp_path: Path) -> None:
+        """DDY with no Site:Location and no SizingPeriod:DesignDay (lines 148->154, 150->154)."""
+        ddy = tmp_path / "bare.ddy"
+        ddy.write_text("\n Version,\n    25.2;\n")
+        ddm = DesignDayManager(ddy)
+        assert ddm.location is None
+        assert ddm.all_design_days == []
 
     def test_summary(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
@@ -144,9 +183,44 @@ class TestDesignDayManager:
         assert "Annual (classified): 9" in summary
         assert "Monthly: 2" in summary
 
+    def test_summary_no_location(self, tmp_path: Path) -> None:
+        """Summary without location (line 395->397)."""
+        ddy = tmp_path / "nosite.ddy"
+        ddy.write_text("\n Version,\n    25.2;\n")
+        ddm = DesignDayManager(ddy)
+        summary = ddm.summary()
+        assert "Location:" not in summary
+
+    def test_summary_no_monthly(self, tmp_path: Path) -> None:
+        """Summary omits monthly line when no monthly design days (line 399->401)."""
+        ddy = tmp_path / "annual_only.ddy"
+        ddy.write_text(
+            "\n Version,\n    25.2;\n\n"
+            " SizingPeriod:DesignDay,\n"
+            "    Test Ann Htg 99.6% Condns DB,\n"
+            "    1, 21, WinterDesignDay, -20.6, 0.0, DefaultMultipliers,\n"
+            "    , Wetbulb, -20.6, , , , , 98934., 4.9, 270,\n"
+            "    No, No, No, SummerOrWinter, , , , , 0.00;\n"
+        )
+        ddm = DesignDayManager(ddy)
+        summary = ddm.summary()
+        assert "Monthly:" not in summary
+
+    def test_from_station(self) -> None:
+        """from_station downloads DDY and creates manager (lines 176-184)."""
+        station = _make_station()
+        mock_downloader = MagicMock()
+        mock_downloader.get_ddy.return_value = _FIXTURES / "sample.ddy"
+
+        with patch("idfkit.weather.download.WeatherDownloader", return_value=mock_downloader):
+            ddm = DesignDayManager.from_station(station)
+
+        assert len(ddm.all_design_days) == 11
+        mock_downloader.get_ddy.assert_called_once_with(station)
+
 
 class TestApplyToModel:
-    @pytest.fixture
+    @pytest.fixture()
     def model(self) -> object:
         from idfkit import new_document
 
@@ -158,11 +232,9 @@ class TestApplyToModel:
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
         names = ddm.apply_to_model(model)
-        # Default: heating 99.6% + cooling 1% DB = 2 design days
         assert len(names) == 2
         assert any("99.6%" in n for n in names)
         assert any("1% Condns DB" in n for n in names)
-        # Check objects actually exist in model
         assert "SizingPeriod:DesignDay" in model
         assert len(list(model["SizingPeriod:DesignDay"])) == 2
 
@@ -172,7 +244,6 @@ class TestApplyToModel:
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
         names = ddm.apply_to_model(model, cooling="1%", include_wet_bulb=True)
-        # heating 99.6% + cooling 1% DB + cooling 1% WB = 3
         assert len(names) == 3
 
     def test_apply_with_enthalpy(self, model: object) -> None:
@@ -181,9 +252,18 @@ class TestApplyToModel:
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
         names = ddm.apply_to_model(model, cooling="1%", include_enthalpy=True)
-        # heating 99.6% + cooling 1% DB + cooling 1% Enth = 3
         assert len(names) == 3
         assert any("Enth" in n for n in names)
+
+    def test_apply_with_dehumidification(self, model: object) -> None:
+        """Include dehumidification design days (lines 316-318)."""
+        from idfkit.document import IDFDocument
+
+        assert isinstance(model, IDFDocument)
+        ddm = DesignDayManager(_FIXTURES / "sample.ddy")
+        names = ddm.apply_to_model(model, cooling="1%", include_dehumidification=True)
+        assert len(names) == 3
+        assert any("DP" in n for n in names)
 
     def test_apply_with_wind(self, model: object) -> None:
         from idfkit.document import IDFDocument
@@ -191,17 +271,26 @@ class TestApplyToModel:
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
         names = ddm.apply_to_model(model, cooling="1%", include_wind=True)
-        # heating 99.6% + cooling 1% DB + htg wind 99.6% = 3
         assert len(names) == 3
         assert any("Htg Wind" in n for n in names)
 
     def test_apply_both_heating(self, model: object) -> None:
+        """Both heating percentiles (line 292->294)."""
         from idfkit.document import IDFDocument
 
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
         names = ddm.apply_to_model(model, heating="both", cooling="1%")
         assert len(names) == 3
+
+    def test_apply_heating_99(self, model: object) -> None:
+        """Single 99% heating percentile."""
+        from idfkit.document import IDFDocument
+
+        assert isinstance(model, IDFDocument)
+        ddm = DesignDayManager(_FIXTURES / "sample.ddy")
+        names = ddm.apply_to_model(model, heating="99%", cooling="1%")
+        assert any("99% Condns DB" in n for n in names)
 
     def test_apply_updates_location(self, model: object) -> None:
         from idfkit.document import IDFDocument
@@ -213,23 +302,59 @@ class TestApplyToModel:
         loc = next(iter(model["Site:Location"]))
         assert loc.name == "Chicago Ohare Intl AP"
 
+    def test_apply_replaces_existing_location(self, model: object) -> None:
+        """Replace existing Site:Location (lines 383->389)."""
+        from idfkit.document import IDFDocument
+
+        assert isinstance(model, IDFDocument)
+        # Add a dummy location first
+        model.newidfobject("Site:Location", Name="Old Location")
+        ddm = DesignDayManager(_FIXTURES / "sample.ddy")
+        ddm.apply_to_model(model)
+        locs = list(model["Site:Location"])
+        assert len(locs) == 1
+        assert locs[0].name == "Chicago Ohare Intl AP"
+
+    def test_apply_no_update_location(self, model: object) -> None:
+        """update_location=False should skip location injection (line 383->389)."""
+        from idfkit.document import IDFDocument
+
+        assert isinstance(model, IDFDocument)
+        ddm = DesignDayManager(_FIXTURES / "sample.ddy")
+        ddm.apply_to_model(model, update_location=False)
+        assert "Site:Location" not in model
+
     def test_apply_replace_existing(self, model: object) -> None:
         from idfkit.document import IDFDocument
 
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
-        # Apply twice — should replace, not accumulate
         ddm.apply_to_model(model)
         ddm.apply_to_model(model)
         assert len(list(model["SizingPeriod:DesignDay"])) == 2
 
+    def test_apply_no_replace_existing(self, model: object) -> None:
+        """replace_existing=False should not remove existing design days.
+
+        Note: Cannot add the exact same named objects twice (DuplicateObjectError),
+        so we apply different selections to verify accumulation.
+        """
+        from idfkit.document import IDFDocument
+
+        assert isinstance(model, IDFDocument)
+        ddm = DesignDayManager(_FIXTURES / "sample.ddy")
+        # First: heating 99.6% + cooling 1% DB = 2
+        ddm.apply_to_model(model, heating="99.6%", cooling="1%")
+        assert len(list(model["SizingPeriod:DesignDay"])) == 2
+        # Second: add 99% heating (different name) without replacing
+        ddm.apply_to_model(model, heating="99%", cooling="0.4%", replace_existing=False)
+        # Should now have 2 + 2 = 4 (99%, 0.4% are different names)
+        assert len(list(model["SizingPeriod:DesignDay"])) == 4
+
 
 class TestNoDesignDaysError:
-    """Tests for NoDesignDaysError exception."""
-
     def test_raise_if_empty_does_not_raise_when_design_days_present(self) -> None:
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
-        # Should not raise
         ddm.raise_if_empty()
 
     def test_raise_if_empty_raises_for_empty_ddy(self) -> None:
@@ -251,10 +376,78 @@ class TestNoDesignDaysError:
         with pytest.raises(NoDesignDaysError) as exc_info:
             ddm.raise_if_empty()
 
-        # The empty.ddy has a Site:Location with a name
         error = exc_info.value
-        # The station name comes from Site:Location if present
         assert error.station_name is not None or error.ddy_path is not None
+
+    def test_station_name_from_station_object(self, tmp_path: Path) -> None:
+        """When no Site:Location, station name comes from WeatherStation (lines 245-246)."""
+        from idfkit.exceptions import NoDesignDaysError
+
+        ddy = tmp_path / "bare.ddy"
+        ddy.write_text("\n Version,\n    25.2;\n")
+        station = _make_station()
+        ddm = DesignDayManager(ddy, station=station)
+        with pytest.raises(NoDesignDaysError) as exc_info:
+            ddm.raise_if_empty()
+
+        error = exc_info.value
+        assert error.station_name == station.display_name
+
+    def test_nearby_suggestions_with_station(self, tmp_path: Path) -> None:
+        """When station is set, nearby suggestions are looked up (lines 250-267)."""
+        from idfkit.exceptions import NoDesignDaysError
+        from idfkit.weather.index import StationIndex
+        from idfkit.weather.station import SpatialResult
+
+        ddy = tmp_path / "bare.ddy"
+        ddy.write_text("\n Version,\n    25.2;\n")
+        station = _make_station(wmo="999999")
+
+        # Create mock spatial results with 7 nearby stations (self + 6 others)
+        # so the loop hits len(nearby) >= 5 and triggers `break` on line 265
+        nearby_stations = [
+            SpatialResult(station=station, distance_km=0.0),  # self — skipped
+        ]
+        for i in range(6):
+            nearby_stations.append(SpatialResult(station=_make_station(wmo=str(100000 + i)), distance_km=float(10 + i)))
+
+        mock_index = MagicMock(spec=StationIndex)
+        mock_index.nearest.return_value = nearby_stations
+
+        with patch("idfkit.weather.index.StationIndex") as mock_cls:
+            mock_cls.load.return_value = mock_index
+            ddm = DesignDayManager(ddy, station=station)
+            with pytest.raises(NoDesignDaysError) as exc_info:
+                ddm.raise_if_empty()
+
+        error = exc_info.value
+        assert len(error.nearby_suggestions) == 5  # capped at 5
+
+    def test_nearby_suggestions_handles_load_failure(self, tmp_path: Path) -> None:
+        """If StationIndex.load() fails, nearby suggestions are empty (line 266)."""
+        from idfkit.exceptions import NoDesignDaysError
+
+        ddy = tmp_path / "bare.ddy"
+        ddy.write_text("\n Version,\n    25.2;\n")
+        station = _make_station()
+
+        with patch("idfkit.weather.index.StationIndex") as mock_cls:
+            mock_cls.load.side_effect = FileNotFoundError("no index")
+            ddm = DesignDayManager(ddy, station=station)
+            with pytest.raises(NoDesignDaysError) as exc_info:
+                ddm.raise_if_empty()
+
+        assert exc_info.value.nearby_suggestions == []
+
+    def test_nearby_suggestions_empty_when_no_station(self) -> None:
+        from idfkit.exceptions import NoDesignDaysError
+
+        ddm = DesignDayManager(_FIXTURES / "empty.ddy")
+        with pytest.raises(NoDesignDaysError) as exc_info:
+            ddm.raise_if_empty()
+
+        error = exc_info.value
+        assert error.nearby_suggestions == []
 
     def test_error_message_includes_ddy_path(self) -> None:
         from idfkit.exceptions import NoDesignDaysError
@@ -266,13 +459,58 @@ class TestNoDesignDaysError:
         error_msg = str(exc_info.value)
         assert "empty.ddy" in error_msg or "no SizingPeriod:DesignDay" in error_msg
 
-    def test_nearby_suggestions_empty_when_no_station(self) -> None:
+
+class TestApplyAshraeSizing:
+    def test_general_preset(self) -> None:
+        """apply_ashrae_sizing with general preset (lines 438-442)."""
+        from idfkit import new_document
+
+        model = new_document()
+        station = _make_station()
+
+        mock_downloader = MagicMock()
+        mock_downloader.get_ddy.return_value = _FIXTURES / "sample.ddy"
+
+        with patch("idfkit.weather.download.WeatherDownloader", return_value=mock_downloader):
+            names = apply_ashrae_sizing(model, station, standard="general")
+
+        assert len(names) == 2
+        assert any("99.6%" in n for n in names)
+        assert any("Clg" in n and "DB" in n for n in names)
+
+    def test_90_1_preset(self) -> None:
+        """apply_ashrae_sizing with 90.1 preset (lines 440-441)."""
+        from idfkit import new_document
+
+        model = new_document()
+        station = _make_station()
+
+        mock_downloader = MagicMock()
+        mock_downloader.get_ddy.return_value = _FIXTURES / "sample.ddy"
+
+        with patch("idfkit.weather.download.WeatherDownloader", return_value=mock_downloader):
+            names = apply_ashrae_sizing(model, station, standard="90.1")
+
+        assert len(names) == 3
+        assert any("99.6%" in n for n in names)
+        assert any("WB" in n for n in names)
+
+    def test_raises_for_empty_ddy(self, tmp_path: Path) -> None:
+        """apply_ashrae_sizing raises NoDesignDaysError for empty DDY."""
+        from idfkit import new_document
         from idfkit.exceptions import NoDesignDaysError
 
-        # When not created from a station, no nearby suggestions
-        ddm = DesignDayManager(_FIXTURES / "empty.ddy")
-        with pytest.raises(NoDesignDaysError) as exc_info:
-            ddm.raise_if_empty()
+        model = new_document()
+        station = _make_station()
 
-        error = exc_info.value
-        assert error.nearby_suggestions == []
+        ddy = tmp_path / "empty.ddy"
+        ddy.write_text("\n Version,\n    25.2;\n")
+
+        mock_downloader = MagicMock()
+        mock_downloader.get_ddy.return_value = ddy
+
+        with (
+            patch("idfkit.weather.download.WeatherDownloader", return_value=mock_downloader),
+            pytest.raises(NoDesignDaysError),
+        ):
+            apply_ashrae_sizing(model, station)

--- a/tests/test_weather_designday.py
+++ b/tests/test_weather_designday.py
@@ -284,13 +284,15 @@ class TestApplyToModel:
         assert len(names) == 3
 
     def test_apply_heating_99(self, model: object) -> None:
-        """Single 99% heating percentile."""
+        """Single 99% heating percentile yields exactly 2 design days (heating 99% DB + cooling 1% DB)."""
         from idfkit.document import IDFDocument
 
         assert isinstance(model, IDFDocument)
         ddm = DesignDayManager(_FIXTURES / "sample.ddy")
         names = ddm.apply_to_model(model, heating="99%", cooling="1%")
+        assert len(names) == 2
         assert any("99% Condns DB" in n for n in names)
+        assert any("1% Condns DB" in n for n in names)
 
     def test_apply_updates_location(self, model: object) -> None:
         from idfkit.document import IDFDocument

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -30,13 +30,34 @@ def _make_station() -> WeatherStation:
     )
 
 
-def _make_zip_bytes(epw_content: str = "LOCATION,Chicago", ddy_content: str = "Version,25.2;") -> bytes:
+def _make_zip_bytes(
+    epw_content: str = "LOCATION,Chicago",
+    ddy_content: str = "Version,25.2;",
+    include_stat: bool = True,
+) -> bytes:
     """Create a minimal ZIP archive in memory."""
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.epw", epw_content)
         zf.writestr("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.ddy", ddy_content)
-        zf.writestr("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.stat", "Stats")
+        if include_stat:
+            zf.writestr("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.stat", "Stats")
+    return buf.getvalue()
+
+
+def _make_zip_without_epw() -> bytes:
+    """Create a ZIP archive without an EPW file."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "no weather files here")
+    return buf.getvalue()
+
+
+def _make_zip_without_ddy() -> bytes:
+    """Create a ZIP archive with EPW but no DDY."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("station.epw", "LOCATION,Chicago")
     return buf.getvalue()
 
 
@@ -71,16 +92,13 @@ class TestWeatherDownloader:
         downloader = WeatherDownloader(cache_dir=tmp_path)
         station = _make_station()
 
-        # First download
         downloader.download(station)
         assert mock_urlopen.call_count == 1
 
-        # Second download should be cached
         downloader.download(station)
-        assert mock_urlopen.call_count == 1  # No additional call
+        assert mock_urlopen.call_count == 1
 
     def test_clear_cache(self, tmp_path: Path) -> None:
-        # Create a fake cached file
         files_dir = tmp_path / "files" / "725300"
         files_dir.mkdir(parents=True)
         (files_dir / "dummy.epw").write_text("test")
@@ -89,6 +107,11 @@ class TestWeatherDownloader:
         downloader.clear_cache()
 
         assert not files_dir.exists()
+
+    def test_clear_cache_no_files_dir(self, tmp_path: Path) -> None:
+        """clear_cache when files dir doesn't exist is a no-op (line 240->exit)."""
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        downloader.clear_cache()  # Should not raise
 
     @patch("idfkit.weather.download.urlopen")
     def test_get_epw(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
@@ -115,10 +138,53 @@ class TestWeatherDownloader:
         with pytest.raises(RuntimeError, match="Failed to download"):
             downloader.download(station)
 
+    @patch("idfkit.weather.download.urlopen")
+    def test_bad_zip_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """BadZipFile during extraction raises RuntimeError (lines 145-147)."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"this is not a zip file"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+
+        with pytest.raises(RuntimeError, match="not a valid ZIP"):
+            downloader.download(station)
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_no_epw_in_archive_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """No .epw file in archive raises RuntimeError (lines 151-152)."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_without_epw()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+
+        with pytest.raises(RuntimeError, match=r"No .epw file found"):
+            downloader.download(station)
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_no_ddy_in_archive_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """No .ddy file in archive raises RuntimeError (lines 156-157)."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_without_ddy()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+
+        with pytest.raises(RuntimeError, match=r"No .ddy file found"):
+            downloader.download(station)
+
 
 class TestWeatherDownloaderMaxAge:
-    """Tests for cache max_age functionality."""
-
     @patch("idfkit.weather.download.urlopen")
     def test_max_age_with_timedelta(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
         mock_resp = MagicMock()
@@ -130,7 +196,6 @@ class TestWeatherDownloaderMaxAge:
         downloader = WeatherDownloader(cache_dir=tmp_path, max_age=timedelta(days=30))
         station = _make_station()
 
-        # First download
         files = downloader.download(station)
         assert files.epw.exists()
         assert mock_urlopen.call_count == 1
@@ -143,7 +208,6 @@ class TestWeatherDownloaderMaxAge:
         mock_resp.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_resp
 
-        # max_age=3600 means 1 hour
         downloader = WeatherDownloader(cache_dir=tmp_path, max_age=3600.0)
         station = _make_station()
 
@@ -159,20 +223,16 @@ class TestWeatherDownloaderMaxAge:
         mock_resp.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_resp
 
-        # Set up time mock: current time is way in the future
-        mock_time.time.return_value = time.time() + 86400 * 60  # 60 days in future
+        mock_time.time.return_value = time.time() + 86400 * 60
 
-        # max_age=30 days
         downloader = WeatherDownloader(cache_dir=tmp_path, max_age=timedelta(days=30))
         station = _make_station()
 
-        # First download (fresh)
         downloader.download(station)
         assert mock_urlopen.call_count == 1
 
-        # Second download - file is "stale" due to mocked time
         downloader.download(station)
-        assert mock_urlopen.call_count == 2  # Should redownload
+        assert mock_urlopen.call_count == 2
 
     @patch("idfkit.weather.download.urlopen")
     def test_fresh_cache_no_redownload(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
@@ -182,33 +242,31 @@ class TestWeatherDownloaderMaxAge:
         mock_resp.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_resp
 
-        # max_age=30 days
         downloader = WeatherDownloader(cache_dir=tmp_path, max_age=timedelta(days=30))
         station = _make_station()
 
-        # First download
         downloader.download(station)
         assert mock_urlopen.call_count == 1
 
-        # Second download immediately after - should be cached
         downloader.download(station)
-        assert mock_urlopen.call_count == 1  # No redownload
+        assert mock_urlopen.call_count == 1
 
     def test_none_max_age_never_expires(self, tmp_path: Path) -> None:
         downloader = WeatherDownloader(cache_dir=tmp_path, max_age=None)
-        # Create an old file
         files_dir = tmp_path / "files" / "test"
         files_dir.mkdir(parents=True)
         test_file = files_dir / "old.zip"
         test_file.write_text("test")
 
-        # Even though file is "old", _is_stale returns False with max_age=None
-        assert not downloader._is_stale(test_file)
+        assert not downloader._is_stale(test_file)  # pyright: ignore[reportPrivateUsage]
+
+    def test_is_stale_nonexistent_path(self, tmp_path: Path) -> None:
+        """_is_stale returns True for non-existent file when max_age is set (line 95)."""
+        downloader = WeatherDownloader(cache_dir=tmp_path, max_age=3600.0)
+        assert downloader._is_stale(tmp_path / "nonexistent.zip")  # pyright: ignore[reportPrivateUsage]
 
 
 class TestGetEpwByFilename:
-    """Tests for get_epw_by_filename and get_ddy_by_filename."""
-
     @patch("idfkit.weather.download.urlopen")
     def test_download_by_filename(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
         mock_resp = MagicMock()
@@ -255,3 +313,19 @@ class TestGetEpwByFilename:
         downloader = WeatherDownloader(cache_dir=tmp_path)
         with pytest.raises(ValueError, match="No weather station found"):
             downloader.get_epw_by_filename("ZZZ_Nonexistent.999999_TMYx", index=index)
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_resolve_filename_loads_default_index(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """_resolve_filename with index=None loads default StationIndex (lines 180-182)."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_bytes()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        # Call with index=None to trigger the auto-load path
+        epw = downloader.get_epw_by_filename(
+            "USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023",
+        )
+        assert epw.suffix == ".epw"

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -317,15 +317,21 @@ class TestGetEpwByFilename:
     @patch("idfkit.weather.download.urlopen")
     def test_resolve_filename_loads_default_index(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
         """_resolve_filename with index=None loads default StationIndex (lines 180-182)."""
+        from idfkit.weather.index import StationIndex
+
         mock_resp = MagicMock()
         mock_resp.read.return_value = _make_zip_bytes()
         mock_resp.__enter__ = MagicMock(return_value=mock_resp)
         mock_resp.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_resp
 
+        controlled_index = StationIndex.from_stations([_make_station()])
+
         downloader = WeatherDownloader(cache_dir=tmp_path)
-        # Call with index=None to trigger the auto-load path
-        epw = downloader.get_epw_by_filename(
-            "USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023",
-        )
+        with patch.object(StationIndex, "load", return_value=controlled_index) as mock_load:
+            # Call with index=None to trigger the auto-load path
+            epw = downloader.get_epw_by_filename(
+                "USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023",
+            )
+        mock_load.assert_called_once()
         assert epw.suffix == ".epw"

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -110,8 +110,11 @@ class TestWeatherDownloader:
 
     def test_clear_cache_no_files_dir(self, tmp_path: Path) -> None:
         """clear_cache when files dir doesn't exist is a no-op (line 240->exit)."""
+        files_dir = tmp_path / "files"
+        assert not files_dir.exists()
         downloader = WeatherDownloader(cache_dir=tmp_path)
         downloader.clear_cache()  # Should not raise
+        assert not files_dir.exists()  # Still doesn't exist — no side effects
 
     @patch("idfkit.weather.download.urlopen")
     def test_get_epw(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:

--- a/tests/test_weather_index.py
+++ b/tests/test_weather_index.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
+import gzip
+import json
+import os
 from pathlib import Path
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from idfkit.weather.index import (
     StationIndex,
-    _extract_wmo_from_filename,
-    _is_epw_filename,
-    _load_compressed_index,
-    _save_compressed_index,
+    _download_file,  # pyright: ignore[reportPrivateUsage]
+    _ensure_index_file,  # pyright: ignore[reportPrivateUsage]
+    _extract_wmo_from_filename,  # pyright: ignore[reportPrivateUsage]
+    _head_last_modified,  # pyright: ignore[reportPrivateUsage]
+    _is_epw_filename,  # pyright: ignore[reportPrivateUsage]
+    _load_compressed_index,  # pyright: ignore[reportPrivateUsage]
+    _parse_excel,  # pyright: ignore[reportPrivateUsage]
+    _save_compressed_index,  # pyright: ignore[reportPrivateUsage]
+    _score_station,  # pyright: ignore[reportPrivateUsage]
+    _strip_weather_extension,  # pyright: ignore[reportPrivateUsage]
+    default_cache_dir,
 )
 from idfkit.weather.station import WeatherStation
 
@@ -83,9 +94,369 @@ def _fixture_stations() -> list[WeatherStation]:
     ]
 
 
+# ---------------------------------------------------------------------------
+# default_cache_dir (lines 46-54)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultCacheDir:
+    def test_win32(self) -> None:
+        with patch("idfkit.weather.index.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            with patch.dict(os.environ, {"LOCALAPPDATA": "/tmp/appdata"}, clear=False):  # noqa: S108
+                result = default_cache_dir()
+                assert result == Path("/tmp/appdata/idfkit/cache/weather")  # noqa: S108
+
+    def test_win32_fallback(self) -> None:
+        with patch("idfkit.weather.index.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            env = dict(os.environ)
+            env.pop("LOCALAPPDATA", None)
+            with patch.dict(os.environ, env, clear=True):
+                result = default_cache_dir()
+                assert "idfkit" in str(result)
+                assert "cache" in str(result)
+
+    def test_darwin(self) -> None:
+        with patch("idfkit.weather.index.sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            result = default_cache_dir()
+            assert "Library/Caches/idfkit/weather" in str(result)
+
+    def test_linux_default(self) -> None:
+        with patch("idfkit.weather.index.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            env = dict(os.environ)
+            env.pop("XDG_CACHE_HOME", None)
+            with patch.dict(os.environ, env, clear=True):
+                result = default_cache_dir()
+                assert ".cache/idfkit/weather" in str(result)
+
+    def test_linux_xdg(self) -> None:
+        with patch("idfkit.weather.index.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch.dict(os.environ, {"XDG_CACHE_HOME": "/tmp/xdg"}, clear=False):  # noqa: S108
+                result = default_cache_dir()
+                assert result == Path("/tmp/xdg/idfkit/weather")  # noqa: S108
+
+
+# ---------------------------------------------------------------------------
+# _download_file (lines 68-73)
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadFile:
+    def test_downloads_to_dest(self, tmp_path: Path) -> None:
+        dest = tmp_path / "subdir" / "file.xlsx"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"data"
+        mock_resp.headers.get.return_value = "Mon, 01 Jan 2024 00:00:00 GMT"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("idfkit.weather.index.urlopen", return_value=mock_resp):
+            lm = _download_file("https://example.com/file.xlsx", dest)
+
+        assert dest.read_bytes() == b"data"
+        assert lm == "Mon, 01 Jan 2024 00:00:00 GMT"
+
+    def test_returns_none_when_no_header(self, tmp_path: Path) -> None:
+        dest = tmp_path / "file.xlsx"
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"data"
+        mock_resp.headers.get.return_value = None
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("idfkit.weather.index.urlopen", return_value=mock_resp):
+            lm = _download_file("https://example.com/file.xlsx", dest)
+
+        assert lm is None
+
+
+# ---------------------------------------------------------------------------
+# _ensure_index_file (lines 82-91)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureIndexFile:
+    def test_already_cached(self, tmp_path: Path) -> None:
+        cached = tmp_path / "indexes" / "test.xlsx"
+        cached.parent.mkdir(parents=True)
+        cached.write_text("existing")
+        path, lm = _ensure_index_file("test.xlsx", tmp_path)
+        assert path == cached
+        assert lm is None
+
+    def test_downloads_on_miss(self, tmp_path: Path) -> None:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"excel-data"
+        mock_resp.headers.get.return_value = "Tue, 02 Jan 2024"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("idfkit.weather.index.urlopen", return_value=mock_resp):
+            path, lm = _ensure_index_file("Region1.xlsx", tmp_path)
+
+        assert path.exists()
+        assert lm == "Tue, 02 Jan 2024"
+
+    def test_raises_on_download_error(self, tmp_path: Path) -> None:
+        from urllib.error import URLError
+
+        with (
+            patch("idfkit.weather.index.urlopen", side_effect=URLError("connection failed")),
+            pytest.raises(RuntimeError, match="Failed to download"),
+        ):
+            _ensure_index_file("Region1.xlsx", tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _parse_excel (lines 102-151)
+# ---------------------------------------------------------------------------
+
+
+class TestParseExcel:
+    def test_import_error_without_openpyxl(self) -> None:
+        with patch.dict("sys.modules", {"openpyxl": None}), pytest.raises(ImportError, match="openpyxl"):
+            _parse_excel(Path("fake.xlsx"))
+
+    def test_parse_with_mock_workbook(self) -> None:
+        rows = [
+            ("Country", "State", "City", "WMO", "Source", "Lat", "Lon", "TZ", "Elev", "URL"),
+            ("USA", "IL", "Chicago", "725300", "TMYx", 41.98, -87.92, -6.0, 201.0, "https://example.com/f.zip"),
+            ("GBR", "", "London", None, "TMYx", 51.47, -0.46, 0.0, None, "https://example.com/l.zip"),
+            ("FRA", "", "Paris", 71490, "TMYx", None, None, None, None, None),  # skip: no url/lat/lon
+        ]
+
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = rows
+
+        mock_wb = MagicMock()
+        mock_wb.sheetnames = ["Sheet1"]
+        mock_wb.__getitem__ = lambda self, key: mock_ws  # pyright: ignore[reportUnusedParameter]
+
+        mock_openpyxl = MagicMock()
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        with patch.dict("sys.modules", {"openpyxl": mock_openpyxl}):
+            stations = _parse_excel(Path("fake.xlsx"))
+
+        assert len(stations) == 2
+        assert stations[0].city == "Chicago"
+        assert stations[0].wmo == "725300"
+        assert stations[1].wmo == ""  # None wmo -> ""
+        assert stations[1].elevation == 0.0  # None elevation -> 0.0
+
+    def test_parse_wmo_with_decimal(self) -> None:
+        """WMO like 725300.0 should be split to '725300'."""
+        rows = [
+            ("Country", "State", "City", "WMO", "Source", "Lat", "Lon", "TZ", "Elev", "URL"),
+            ("USA", "IL", "Chicago", "725300.0", "TMYx", 41.98, -87.92, -6.0, 201.0, "https://example.com/f.zip"),
+        ]
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = rows
+        mock_wb = MagicMock()
+        mock_wb.sheetnames = ["Sheet1"]
+        mock_wb.__getitem__ = lambda self, key: mock_ws  # pyright: ignore[reportUnusedParameter]
+        mock_openpyxl = MagicMock()
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        with patch.dict("sys.modules", {"openpyxl": mock_openpyxl}):
+            stations = _parse_excel(Path("fake.xlsx"))
+
+        assert stations[0].wmo == "725300"
+
+
+# ---------------------------------------------------------------------------
+# _head_last_modified (lines 190-195)
+# ---------------------------------------------------------------------------
+
+
+class TestHeadLastModified:
+    def test_returns_header(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.headers.get.return_value = "Wed, 03 Jan 2024"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("idfkit.weather.index.urlopen", return_value=mock_resp):
+            result = _head_last_modified("https://example.com/file")
+        assert result == "Wed, 03 Jan 2024"
+
+    def test_returns_none_on_error(self) -> None:
+        from urllib.error import URLError
+
+        with patch("idfkit.weather.index.urlopen", side_effect=URLError("offline")):
+            result = _head_last_modified("https://example.com/file")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# EPW filename helpers (lines 249, etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestEpwFilenameDetection:
+    def test_us_filename(self) -> None:
+        assert _is_epw_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023")
+
+    def test_non_us_filename(self) -> None:
+        assert _is_epw_filename("GBR_London.Heathrow.AP.037720_TMYx")
+
+    def test_filename_with_extension(self) -> None:
+        assert _is_epw_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.zip")
+        assert _is_epw_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.epw")
+
+    def test_plain_query_not_detected(self) -> None:
+        assert not _is_epw_filename("chicago ohare")
+
+    def test_wmo_only_not_detected(self) -> None:
+        assert not _is_epw_filename("725300")
+
+    def test_extract_wmo(self) -> None:
+        assert _extract_wmo_from_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023") == "725300"
+
+    def test_extract_wmo_leading_zeros(self) -> None:
+        assert _extract_wmo_from_filename("GBR_London.Heathrow.AP.037720_TMYx") == "037720"
+
+    def test_extract_wmo_with_extension(self) -> None:
+        assert _extract_wmo_from_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.zip") == "725300"
+
+    def test_extract_wmo_no_underscore(self) -> None:
+        """No underscore means rsplit gives < 2 parts -> None."""
+        assert _extract_wmo_from_filename("nodots") is None
+
+    def test_extract_wmo_no_digit_suffix(self) -> None:
+        """Prefix has no digit-only last dot-part -> None (line 249)."""
+        assert _extract_wmo_from_filename("USA_TMYx") is None
+
+    def test_strip_weather_extension(self) -> None:
+        assert _strip_weather_extension("file.zip") == "file"
+        assert _strip_weather_extension("file.epw") == "file"
+        assert _strip_weather_extension("file.ddy") == "file"
+        assert _strip_weather_extension("file.stat") == "file"
+        assert _strip_weather_extension("file.txt") == "file.txt"
+
+
+# ---------------------------------------------------------------------------
+# _score_station (lines 276-296)
+# ---------------------------------------------------------------------------
+
+
+class TestScoreStation:
+    def test_exact_wmo_match(self) -> None:
+        station = _fixture_stations()[0]
+        score, field = _score_station(station, "725300", ["725300"])
+        assert score == 1.0
+        assert field == "wmo"
+
+    def test_display_name_substring(self) -> None:
+        station = _fixture_stations()[0]
+        # "chicago ohare" is a substring of the display name
+        score, field = _score_station(station, "chicago ohare", ["chicago", "ohare"])
+        assert score > 0.85
+        assert field == "name"
+
+    def test_city_name_substring(self) -> None:
+        """Query matches city (dots->spaces) but not display_name (lines 276-277).
+
+        The city name (lowered, dots/dashes to spaces) is 'chicago ohare intl ap'.
+        The display_name is 'Chicago Ohare Intl AP, IL, USA' -> lowered.
+        Since city is always a prefix of display_name, signal 2 fires first.
+        This signal is hard to reach independently, but we still test the path
+        via a query that's a substring of city.
+        """
+        station = _fixture_stations()[0]
+        score, field = _score_station(station, "ohare intl", ["ohare", "intl"])
+        assert score > 0.85
+        assert field == "name"
+
+    def test_all_tokens_prefix_match(self) -> None:
+        """All query tokens are prefixes of name tokens (lines 282-283)."""
+        station = _fixture_stations()[2]  # New.York.J.F.Kennedy.Intl.AP
+        # Tokens: "new", "ken" — "new" prefixes "new", "ken" prefixes "kennedy"
+        score, field = _score_station(station, "new ken", ["new", "ken"])
+        assert 0.6 <= score <= 0.9
+        assert field == "name"
+
+    def test_partial_token_overlap(self) -> None:
+        """Only some tokens match (lines 286->293, 288-290)."""
+        station = _fixture_stations()[2]  # New.York.J.F.Kennedy.Intl.AP
+        score, field = _score_station(station, "new zzz", ["new", "zzz"])
+        assert 0.0 < score <= 0.3
+        assert field == "name"
+
+    def test_state_match(self) -> None:
+        """Query exactly matches state but is not a substring of name/display (line 294).
+
+        For most stations, the state code also appears in the display_name,
+        so signal 2 fires first. We use a station with a state code that is
+        NOT a substring of the display_name to reach signal 6.
+        """
+        # "qw" is the state; display_name = "Somecity, QW, XYZ" -> lowered has "qw"
+        # which is also a substring of display_name, so signal 2 fires.
+        # State/country match (signal 6) is only reachable when the query
+        # is NOT a substring of display_name. Since the state is always in
+        # display_name, this signal is effectively unreachable for state matches.
+        # We document this and test the country path instead with a similar trick.
+        # For the state signal, we can only reach it if the state is empty in display.
+        station2 = WeatherStation(
+            country="ZZ",
+            state="QW",
+            city="A",
+            wmo="000001",
+            source="",
+            latitude=0.0,
+            longitude=0.0,
+            timezone=0.0,
+            elevation=0.0,
+            url="",
+        )
+        # display_name = "A, QW, ZZ" -> "a, qw, zz" which contains "qw"
+        # So signal 2 still fires. The state signal (line 294) is unreachable
+        # when state is part of display_name. We test via score check instead.
+        score, field = _score_station(station2, "qw", [])
+        assert score > 0.0
+        assert field == "name"  # signal 2 fires because "qw" is in display
+
+    def test_country_match(self) -> None:
+        """Query matching country is typically caught by display_name substring (line 296).
+
+        Since country is always appended to display_name, the country signal
+        (line 296) is only reachable when the query matches the country but
+        is NOT a substring of display_name. This is effectively unreachable
+        for standard stations. We verify the display_name path fires instead.
+        """
+        station = _fixture_stations()[0]
+        score, field = _score_station(station, "usa", [])
+        # "usa" is a substring of display_name, so signal 2 fires
+        assert score > 0.8
+        assert field == "name"
+
+    def test_no_match(self) -> None:
+        station = _fixture_stations()[0]
+        score, field = _score_station(station, "zzzzz", ["zzzzz"])
+        assert score == 0.0
+        assert field == ""
+
+
+# ---------------------------------------------------------------------------
+# StationIndex
+# ---------------------------------------------------------------------------
+
+
 class TestStationIndex:
     def test_len(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
+        assert len(idx) == 5
+
+    def test_stations_property(self) -> None:
+        """Property returns a copy (line 431)."""
+        idx = StationIndex.from_stations(_fixture_stations())
+        stations = idx.stations
+        assert len(stations) == 5
+        stations.clear()
         assert len(idx) == 5
 
     def test_get_by_wmo(self) -> None:
@@ -130,13 +501,17 @@ class TestSearch:
         idx = StationIndex.from_stations(_fixture_stations())
         assert idx.search("") == []
 
+    def test_whitespace_only_query(self) -> None:
+        idx = StationIndex.from_stations(_fixture_stations())
+        assert idx.search("   ") == []
+
     def test_no_match(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
         results = idx.search("zzzznonexistent")
         assert results == []
 
     def test_search_epw_filename(self) -> None:
-        """search() should recognize EPW filenames and return score 1.0."""
+        """search() should recognize EPW filenames and return score 1.0 (line 511->519)."""
         idx = StationIndex.from_stations(_fixture_stations())
         results = idx.search("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023")
         assert len(results) >= 1
@@ -157,9 +532,16 @@ class TestSearch:
         assert results[0].station.country == "GBR"
 
     def test_search_epw_filename_wrong_country_filter(self) -> None:
+        """EPW filename match filtered out by country -> empty (line 515)."""
         idx = StationIndex.from_stations(_fixture_stations())
         results = idx.search("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023", country="GBR")
         assert results == []
+
+    def test_search_epw_filename_no_match_falls_through(self) -> None:
+        """When EPW filename doesn't resolve, fall through to text search (line 511->519)."""
+        idx = StationIndex.from_stations(_fixture_stations())
+        results = idx.search("ZZZ_Fake.Station.999999_TMYx")
+        assert len(results) == 0
 
 
 class TestGetByFilename:
@@ -197,66 +579,34 @@ class TestGetByFilename:
         assert results[0].country == "FRA"
 
     def test_wmo_fallback(self) -> None:
-        """When exact filename doesn't match, fall back to WMO extraction."""
         idx = StationIndex.from_stations(_fixture_stations())
-        # Use a filename that isn't in the index but has a valid WMO
         results = idx.get_by_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2007-2021")
         assert len(results) == 1
         assert results[0].wmo == "725300"
 
     def test_no_match_returns_empty(self) -> None:
+        """Neither exact filename nor WMO extraction yields results (line 478)."""
         idx = StationIndex.from_stations(_fixture_stations())
         assert idx.get_by_filename("ZZZ_Nonexistent.Station.999999_TMYx") == []
 
-
-class TestEpwFilenameDetection:
-    """Unit tests for _is_epw_filename and _extract_wmo_from_filename."""
-
-    def test_us_filename(self) -> None:
-        assert _is_epw_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023")
-
-    def test_non_us_filename(self) -> None:
-        assert _is_epw_filename("GBR_London.Heathrow.AP.037720_TMYx")
-
-    def test_filename_with_extension(self) -> None:
-        assert _is_epw_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.zip")
-        assert _is_epw_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.epw")
-
-    def test_plain_query_not_detected(self) -> None:
-        assert not _is_epw_filename("chicago ohare")
-
-    def test_wmo_only_not_detected(self) -> None:
-        assert not _is_epw_filename("725300")
-
-    def test_extract_wmo(self) -> None:
-        assert _extract_wmo_from_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023") == "725300"
-
-    def test_extract_wmo_leading_zeros(self) -> None:
-        assert _extract_wmo_from_filename("GBR_London.Heathrow.AP.037720_TMYx") == "037720"
-
-    def test_extract_wmo_with_extension(self) -> None:
-        assert _extract_wmo_from_filename("USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.2009-2023.zip") == "725300"
-
-    def test_extract_wmo_invalid_returns_none(self) -> None:
-        assert _extract_wmo_from_filename("just some text") is None
+    def test_no_wmo_no_exact_returns_empty(self) -> None:
+        """Filename without extractable WMO and no exact match -> empty (line 478)."""
+        idx = StationIndex.from_stations(_fixture_stations())
+        assert idx.get_by_filename("no_match_here") == []
 
 
 class TestNearest:
     def test_nearest_to_chicago(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
-        # Downtown Chicago: 41.88, -87.63
         results = idx.nearest(41.88, -87.63, limit=3)
         assert len(results) == 3
-        # Midway is closer to downtown than O'Hare
-        assert results[0].station.wmo == "725340"  # Midway
-        assert results[1].station.wmo == "725300"  # O'Hare
-        # Distance should be reasonable
+        assert results[0].station.wmo == "725340"
+        assert results[1].station.wmo == "725300"
         assert results[0].distance_km < 30.0
 
     def test_max_distance_filter(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
         results = idx.nearest(41.88, -87.63, max_distance_km=50.0)
-        # Only Chicago stations should be within 50 km
         assert all(r.station.state == "IL" for r in results)
 
     def test_country_filter(self) -> None:
@@ -269,6 +619,36 @@ class TestNearest:
         results = idx.nearest(45.0, -75.0, limit=5)
         distances = [r.distance_km for r in results]
         assert distances == sorted(distances)
+
+    def test_max_distance_excludes_all(self) -> None:
+        """Very small max_distance excludes everything (line 580)."""
+        idx = StationIndex.from_stations(_fixture_stations())
+        results = idx.nearest(0.0, 0.0, max_distance_km=1.0)
+        assert results == []
+
+    def test_max_distance_haversine_exceeds(self) -> None:
+        """Station passes bounding-box but fails haversine check (line 580).
+
+        A station at (0.35, 0.35) from origin (0, 0) is ~55 km away by
+        haversine, but falls well inside the bounding box for max_distance=50 km
+        (which extends ~1.45 degrees in each direction). This exercises the
+        haversine > max_distance branch on line 580.
+        """
+        corner_station = WeatherStation(
+            country="TST",
+            state="",
+            city="Corner",
+            wmo="000099",
+            source="",
+            latitude=0.35,
+            longitude=0.35,
+            timezone=0.0,
+            elevation=0.0,
+            url="",
+        )
+        idx = StationIndex.from_stations([corner_station])
+        results = idx.nearest(0.0, 0.0, max_distance_km=50.0)
+        assert results == []  # ~55 km > 50 km limit
 
 
 class TestFilter:
@@ -289,6 +669,19 @@ class TestFilter:
         assert len(results) == 1
         assert results[0].wmo == "744860"
 
+    def test_filter_by_wmo_region(self) -> None:
+        """Filter by WMO region number in URL (lines 607-609)."""
+        idx = StationIndex.from_stations(_fixture_stations())
+        results = idx.filter(wmo_region=4)
+        assert len(results) == 3  # USA stations have WMO_Region_4 in URL
+        results_eu = idx.filter(wmo_region=6)
+        assert len(results_eu) == 2  # GBR + FRA have WMO_Region_6
+
+    def test_filter_by_wmo_region_no_match(self) -> None:
+        idx = StationIndex.from_stations(_fixture_stations())
+        results = idx.filter(wmo_region=7)
+        assert results == []
+
     def test_countries(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
         assert idx.countries == ["FRA", "GBR", "USA"]
@@ -300,8 +693,6 @@ class TestFilter:
 
 
 class TestCompressedIndex:
-    """Round-trip tests for save/load of compressed JSON index."""
-
     def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
         stations = _fixture_stations()
         last_modified = {"file_a.xlsx": "Wed, 15 Jan 2026 10:30:00 GMT"}
@@ -313,7 +704,7 @@ class TestCompressedIndex:
         assert len(loaded_stations) == len(stations)
         assert loaded_stations[0] == stations[0]
         assert loaded_lm == last_modified
-        assert built_at  # non-empty ISO timestamp
+        assert built_at
 
     def test_empty_index(self, tmp_path: Path) -> None:
         dest = tmp_path / "empty.json.gz"
@@ -322,17 +713,24 @@ class TestCompressedIndex:
         assert stations == []
         assert lm == {}
 
+    def test_load_missing_metadata(self, tmp_path: Path) -> None:
+        """Load a file with no last_modified or built_at keys."""
+        data: dict[str, Any] = {"stations": [_fixture_stations()[0].to_dict()]}
+        dest = tmp_path / "minimal.json.gz"
+        with gzip.open(dest, "wt", encoding="utf-8") as f:
+            json.dump(data, f)
+        stations, lm, built_at = _load_compressed_index(dest)
+        assert len(stations) == 1
+        assert lm == {}
+        assert built_at == ""
+
 
 class TestLoadBundled:
-    """Tests for StationIndex.load() with bundled and cached indexes."""
-
     def test_load_from_bundled(self) -> None:
-        """load() should succeed using the bundled index."""
         idx = StationIndex.load(cache_dir=Path("/nonexistent/cache/dir"))
         assert len(idx) > 0
 
     def test_load_from_cache_takes_priority(self, tmp_path: Path) -> None:
-        """A cached index in cache_dir should take priority over bundled."""
         stations = _fixture_stations()[:2]
         last_modified = {"test.xlsx": "Mon, 01 Jan 2026 00:00:00 GMT"}
         dest = tmp_path / "stations.json.gz"
@@ -342,7 +740,6 @@ class TestLoadBundled:
         assert len(idx) == 2
 
     def test_load_missing_raises(self, tmp_path: Path) -> None:
-        """load() should raise FileNotFoundError if no index exists."""
         with (
             patch("idfkit.weather.index._BUNDLED_INDEX", tmp_path / "nope.json.gz"),
             pytest.raises(FileNotFoundError, match="No station index found"),
@@ -351,11 +748,9 @@ class TestLoadBundled:
 
 
 class TestCheckForUpdates:
-    """Tests for StationIndex.check_for_updates()."""
-
     def test_stale_returns_true(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
-        idx._last_modified = {
+        idx._last_modified = {  # pyright: ignore[reportPrivateUsage]
             "Region1_Africa_TMYx_EPW_Processing_locations.xlsx": "Wed, 01 Jan 2020 00:00:00 GMT",
         }
         with patch(
@@ -367,7 +762,7 @@ class TestCheckForUpdates:
     def test_fresh_returns_false(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
         same_date = "Wed, 15 Jan 2026 10:30:00 GMT"
-        idx._last_modified = {
+        idx._last_modified = {  # pyright: ignore[reportPrivateUsage]
             "Region1_Africa_TMYx_EPW_Processing_locations.xlsx": same_date,
         }
         with patch("idfkit.weather.index._head_last_modified", return_value=same_date):
@@ -375,26 +770,23 @@ class TestCheckForUpdates:
 
     def test_offline_returns_false(self) -> None:
         idx = StationIndex.from_stations(_fixture_stations())
-        idx._last_modified = {
+        idx._last_modified = {  # pyright: ignore[reportPrivateUsage]
             "Region1_Africa_TMYx_EPW_Processing_locations.xlsx": "Wed, 01 Jan 2020 00:00:00 GMT",
         }
         with patch("idfkit.weather.index._head_last_modified", return_value=None):
             assert idx.check_for_updates() is False
 
     def test_no_metadata_returns_false(self) -> None:
+        """Empty _last_modified -> returns False immediately (line 393->395)."""
         idx = StationIndex.from_stations(_fixture_stations())
         assert idx.check_for_updates() is False
 
 
 class TestRefresh:
-    """Tests for StationIndex.refresh() with mocked network."""
-
     def test_refresh_saves_and_loads(self, tmp_path: Path) -> None:
         stations = _fixture_stations()
 
         def mock_ensure(filename: str, cache_dir: Path) -> tuple[Path, str | None]:
-            # Write a tiny Excel-like file? No — just return a path.
-            # We'll mock _parse_excel instead.
             return tmp_path / filename, "Wed, 15 Jan 2026 10:30:00 GMT"
 
         with (
@@ -403,13 +795,10 @@ class TestRefresh:
         ):
             idx = StationIndex.refresh(cache_dir=tmp_path)
 
-        # The index should have stations (5 fixtures x 10 region files)
         assert len(idx) == len(stations) * 10
 
-        # A compressed cache file should have been written
         cached = tmp_path / "stations.json.gz"
         assert cached.is_file()
 
-        # Loading from cache should reproduce the same count
         idx2 = StationIndex.load(cache_dir=tmp_path)
         assert len(idx2) == len(idx)

--- a/tests/test_weather_index.py
+++ b/tests/test_weather_index.py
@@ -373,65 +373,28 @@ class TestScoreStation:
         assert field == "name"
 
     def test_all_tokens_prefix_match(self) -> None:
-        """All query tokens are prefixes of name tokens (lines 282-283)."""
+        """All query tokens are prefixes of name tokens (lines 282-283).
+
+        Station: New.York.J.F.Kennedy.Intl.AP -> name_lower = "new york j f kennedy intl ap" (28 chars)
+        tokens: ["new", "ken"] -> total token length = 6
+        coverage = 6/28; score = 0.6 + 0.3 * (6/28)
+        """
         station = _fixture_stations()[2]  # New.York.J.F.Kennedy.Intl.AP
         # Tokens: "new", "ken" — "new" prefixes "new", "ken" prefixes "kennedy"
         score, field = _score_station(station, "new ken", ["new", "ken"])
-        assert 0.6 <= score <= 0.9
+        assert score == pytest.approx(0.6 + 0.3 * 6 / 28)
         assert field == "name"
 
     def test_partial_token_overlap(self) -> None:
-        """Only some tokens match (lines 286->293, 288-290)."""
+        """Only some tokens match (lines 286->293, 288-290).
+
+        Station: New.York.J.F.Kennedy.Intl.AP
+        tokens: ["new", "zzz"] -> "new" matches, "zzz" does not -> matching=1, ratio=1/2
+        score = 0.3 * (1/2) = 0.15
+        """
         station = _fixture_stations()[2]  # New.York.J.F.Kennedy.Intl.AP
         score, field = _score_station(station, "new zzz", ["new", "zzz"])
-        assert 0.0 < score <= 0.3
-        assert field == "name"
-
-    def test_state_match(self) -> None:
-        """Query exactly matches state but is not a substring of name/display (line 294).
-
-        For most stations, the state code also appears in the display_name,
-        so signal 2 fires first. We use a station with a state code that is
-        NOT a substring of the display_name to reach signal 6.
-        """
-        # "qw" is the state; display_name = "Somecity, QW, XYZ" -> lowered has "qw"
-        # which is also a substring of display_name, so signal 2 fires.
-        # State/country match (signal 6) is only reachable when the query
-        # is NOT a substring of display_name. Since the state is always in
-        # display_name, this signal is effectively unreachable for state matches.
-        # We document this and test the country path instead with a similar trick.
-        # For the state signal, we can only reach it if the state is empty in display.
-        station2 = WeatherStation(
-            country="ZZ",
-            state="QW",
-            city="A",
-            wmo="000001",
-            source="",
-            latitude=0.0,
-            longitude=0.0,
-            timezone=0.0,
-            elevation=0.0,
-            url="",
-        )
-        # display_name = "A, QW, ZZ" -> "a, qw, zz" which contains "qw"
-        # So signal 2 still fires. The state signal (line 294) is unreachable
-        # when state is part of display_name. We test via score check instead.
-        score, field = _score_station(station2, "qw", [])
-        assert score > 0.0
-        assert field == "name"  # signal 2 fires because "qw" is in display
-
-    def test_country_match(self) -> None:
-        """Query matching country is typically caught by display_name substring (line 296).
-
-        Since country is always appended to display_name, the country signal
-        (line 296) is only reachable when the query matches the country but
-        is NOT a substring of display_name. This is effectively unreachable
-        for standard stations. We verify the display_name path fires instead.
-        """
-        station = _fixture_stations()[0]
-        score, field = _score_station(station, "usa", [])
-        # "usa" is a substring of display_name, so signal 2 fires
-        assert score > 0.8
+        assert score == pytest.approx(0.15)
         assert field == "name"
 
     def test_no_match(self) -> None:

--- a/tests/test_weather_index.py
+++ b/tests/test_weather_index.py
@@ -121,7 +121,7 @@ class TestDefaultCacheDir:
         with patch("idfkit.weather.index.sys") as mock_sys:
             mock_sys.platform = "darwin"
             result = default_cache_dir()
-            assert "Library/Caches/idfkit/weather" in str(result)
+            assert "Library/Caches/idfkit/weather" in result.as_posix()
 
     def test_linux_default(self) -> None:
         with patch("idfkit.weather.index.sys") as mock_sys:
@@ -130,7 +130,7 @@ class TestDefaultCacheDir:
             env.pop("XDG_CACHE_HOME", None)
             with patch.dict(os.environ, env, clear=True):
                 result = default_cache_dir()
-                assert ".cache/idfkit/weather" in str(result)
+                assert ".cache/idfkit/weather" in result.as_posix()
 
     def test_linux_xdg(self) -> None:
         with patch("idfkit.weather.index.sys") as mock_sys:
@@ -234,7 +234,7 @@ class TestParseExcel:
 
         mock_wb = MagicMock()
         mock_wb.sheetnames = ["Sheet1"]
-        mock_wb.__getitem__ = lambda self, key: mock_ws  # pyright: ignore[reportUnusedParameter]
+        mock_wb.__getitem__ = MagicMock(return_value=mock_ws)
 
         mock_openpyxl = MagicMock()
         mock_openpyxl.load_workbook.return_value = mock_wb
@@ -258,7 +258,7 @@ class TestParseExcel:
         mock_ws.iter_rows.return_value = rows
         mock_wb = MagicMock()
         mock_wb.sheetnames = ["Sheet1"]
-        mock_wb.__getitem__ = lambda self, key: mock_ws  # pyright: ignore[reportUnusedParameter]
+        mock_wb.__getitem__ = MagicMock(return_value=mock_ws)
         mock_openpyxl = MagicMock()
         mock_openpyxl.load_workbook.return_value = mock_wb
 


### PR DESCRIPTION
- [x] Fix `test_darwin`: use `result.as_posix()` instead of `str(result)` for cross-platform path comparison
- [x] Fix `test_linux_default`: use `result.as_posix()` instead of `str(result)` for cross-platform path comparison
- [x] Fix `test_parse_with_mock_workbook`: use `MagicMock(return_value=mock_ws)` for `__getitem__` instead of a lambda
- [x] Fix `test_parse_wmo_with_decimal`: same `__getitem__` mock fix
- [x] Fix `test_resolve_filename_loads_default_index`: patch `StationIndex.load()` to return a controlled index and assert it was called