### PR TITLE
Coverage: simulation/result.py (100%)

### DIFF
--- a/tests/test_simulation_result.py
+++ b/tests/test_simulation_result.py
@@ -7,14 +7,34 @@ import sqlite3
 from pathlib import Path
 
 import pytest
-from conftest import InMemoryFileSystem
+from conftest import InMemoryAsyncFileSystem, InMemoryFileSystem
 
 from idfkit.simulation.outputs import OutputVariableIndex
 from idfkit.simulation.parsers.csv import CSVResult
+from idfkit.simulation.parsers.html import HTMLResult
 from idfkit.simulation.parsers.sql import SQLResult
 from idfkit.simulation.result import SimulationResult
 
 FIXTURES = Path(__file__).parent / "fixtures" / "simulation"
+
+_FIXTURE_FILES: list[tuple[str, str]] = [
+    ("eplusout.rdd", "sample.rdd"),
+    ("eplusout.mdd", "sample.mdd"),
+    ("eplusout.csv", "sample.csv"),
+    ("eplusout.err", "sample.err"),
+]
+
+
+def _make_result(run_dir: Path) -> SimulationResult:
+    """Create a minimal SimulationResult pointing at run_dir with no I/O backends."""
+    return SimulationResult(
+        run_dir=run_dir,
+        success=True,
+        exit_code=0,
+        stdout="",
+        stderr="",
+        runtime_seconds=0.0,
+    )
 
 
 def _create_minimal_sql(path: Path) -> None:
@@ -100,15 +120,7 @@ class TestSqlProperty:
         assert sql1 is sql2
 
     def test_none_when_no_file(self, tmp_path: Path) -> None:
-        r = SimulationResult(
-            run_dir=tmp_path,
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            runtime_seconds=0.0,
-        )
-        assert r.sql is None
+        assert _make_result(tmp_path).sql is None
 
     def test_can_query(self, result: SimulationResult) -> None:
         sql = result.sql
@@ -137,15 +149,7 @@ class TestVariablesProperty:
         assert len(variables.meters) == 5
 
     def test_none_when_no_file(self, tmp_path: Path) -> None:
-        r = SimulationResult(
-            run_dir=tmp_path,
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            runtime_seconds=0.0,
-        )
-        assert r.variables is None
+        assert _make_result(tmp_path).variables is None
 
 
 class TestCsvProperty:
@@ -166,15 +170,7 @@ class TestCsvProperty:
         assert len(csv.columns) == 2
 
     def test_none_when_no_file(self, tmp_path: Path) -> None:
-        r = SimulationResult(
-            run_dir=tmp_path,
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            runtime_seconds=0.0,
-        )
-        assert r.csv is None
+        assert _make_result(tmp_path).csv is None
 
 
 class TestFromDirectory:
@@ -194,20 +190,11 @@ class TestFromDirectory:
 
 def _populate_memory_fs(fs: InMemoryFileSystem, run_dir: str, tmp_path: Path) -> None:
     """Load fixture files into an InMemoryFileSystem."""
-    fixtures = Path(__file__).parent / "fixtures" / "simulation"
-    for name, fixture_name in [
-        ("eplusout.rdd", "sample.rdd"),
-        ("eplusout.mdd", "sample.mdd"),
-        ("eplusout.csv", "sample.csv"),
-        ("eplusout.err", "sample.err"),
-    ]:
-        data = (fixtures / fixture_name).read_bytes()
-        fs.write_bytes(f"{run_dir}/{name}", data)
+    for name, fixture_name in _FIXTURE_FILES:
+        fs.write_bytes(f"{run_dir}/{name}", (FIXTURES / fixture_name).read_bytes())
 
-    # SQL needs a real local file — write it to the fs as raw bytes
     sql_path = tmp_path / "temp.sql"
     _create_minimal_sql(sql_path)
-    fs.write_bytes(f"{run_dir}/{name}", sql_path.read_bytes())
     fs.write_bytes(f"{run_dir}/eplusout.sql", sql_path.read_bytes())
 
 
@@ -276,3 +263,358 @@ class TestFsIntegration:
         result = SimulationResult.from_directory("empty/dir", fs=fs)
         assert result.err_path is None
         assert result.csv_path is None
+
+
+# ---------------------------------------------------------------------------
+# Basic edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestBasicEdgeCases:
+    """Tests for validation, path properties, and error branches."""
+
+    def test_post_init_raises_when_both_fs_provided(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        async_fs = InMemoryAsyncFileSystem()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            SimulationResult(
+                run_dir=tmp_path,
+                success=True,
+                exit_code=0,
+                stdout="",
+                stderr="",
+                runtime_seconds=0.0,
+                fs=fs,
+                async_fs=async_fs,
+            )
+
+    def test_errors_returns_empty_when_no_err_file(self, tmp_path: Path) -> None:
+        assert _make_result(tmp_path).errors.raw_text == ""
+
+    def test_errors_from_local_file(self, result_dir: Path) -> None:
+        assert _make_result(result_dir).errors.raw_text != ""
+
+    def test_eso_path_none_when_missing(self, tmp_path: Path) -> None:
+        assert _make_result(tmp_path).eso_path is None
+
+    def test_eso_path_when_present(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.eso").write_text("eso content")
+        assert _make_result(tmp_path).eso_path is not None
+
+    def test_html_path_none_when_missing(self, tmp_path: Path) -> None:
+        assert _make_result(tmp_path).html_path is None
+
+    def test_html_path_with_htm_extension(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.htm").write_text("<html></html>")
+        assert _make_result(tmp_path).html_path is not None
+
+    def test_html_path_with_html_extension(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.html").write_text("<html></html>")
+        assert _make_result(tmp_path).html_path is not None
+
+    def test_find_output_file_glob_fallback(self, tmp_path: Path) -> None:
+        """When primary name not found, scan directory for any matching file."""
+        (tmp_path / "othernameout.err").write_text("err content")
+        assert _make_result(tmp_path).err_path is not None
+
+    def test_find_output_file_raises_for_async_fs_only(self, tmp_path: Path) -> None:
+        result = SimulationResult(
+            run_dir=tmp_path,
+            success=True,
+            exit_code=0,
+            stdout="",
+            stderr="",
+            runtime_seconds=0.0,
+            async_fs=InMemoryAsyncFileSystem(),
+        )
+        with pytest.raises(RuntimeError, match="AsyncFileSystem"):
+            _ = result.err_path
+
+    def test_errors_is_cached(self, result_dir: Path) -> None:
+        result = _make_result(result_dir)
+        e1 = result.errors
+        e2 = result.errors
+        assert e1 is e2
+
+    def test_find_output_file_fs_glob_fallback(self) -> None:
+        """When primary name not found in fs, glob fallback returns a match."""
+        fs = InMemoryFileSystem()
+        run_dir = "output/glob_fallback"
+        fs.write_bytes(f"{run_dir}/othernameout.err", b"err content")
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        assert result.err_path is not None
+
+
+# ---------------------------------------------------------------------------
+# HTML property tests
+# ---------------------------------------------------------------------------
+
+_MINIMAL_HTML = """\
+<html><body>
+<p><b>Report: AnnualBuildingUtilityPerformanceSummary</b></p>
+<p>For: Entire Facility</p>
+<b>Site and Source Energy</b>
+<table>
+<tr><th>Category</th><th>Value</th></tr>
+<tr><td>Total</td><td>100</td></tr>
+</table>
+</body></html>
+"""
+
+
+class TestHtmlProperty:
+    """Tests for SimulationResult.html."""
+
+    def test_none_when_no_file(self, tmp_path: Path) -> None:
+        assert _make_result(tmp_path).html is None
+
+    def test_cached_none(self, tmp_path: Path) -> None:
+        result = _make_result(tmp_path)
+        h1 = result.html
+        h2 = result.html
+        assert h1 is h2
+        assert h1 is None
+
+    def test_returns_html_result_from_file(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.htm").write_text(_MINIMAL_HTML, encoding="latin-1")
+        assert isinstance(_make_result(tmp_path).html, HTMLResult)
+
+    def test_is_cached(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.htm").write_text(_MINIMAL_HTML, encoding="latin-1")
+        result = _make_result(tmp_path)
+        h1 = result.html
+        h2 = result.html
+        assert h1 is h2
+
+    def test_html_via_fs(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sim_html"
+        fs.write_text(f"{run_dir}/eplusout.htm", _MINIMAL_HTML, encoding="latin-1")
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        html = result.html
+        assert isinstance(html, HTMLResult)
+
+
+# ---------------------------------------------------------------------------
+# Async accessor tests
+# ---------------------------------------------------------------------------
+
+
+def _populate_async_fs(async_fs: InMemoryAsyncFileSystem, run_dir: str, sql_path: Path) -> None:
+    """Load fixture files directly into an InMemoryAsyncFileSystem's backing store."""
+    files = async_fs._files  # pyright: ignore[reportPrivateUsage]
+    norm = async_fs._norm  # pyright: ignore[reportPrivateUsage]
+    for name, fixture_name in _FIXTURE_FILES:
+        files[norm(f"{run_dir}/{name}")] = (FIXTURES / fixture_name).read_bytes()
+    files[norm(f"{run_dir}/eplusout.sql")] = sql_path.read_bytes()
+    files[norm(f"{run_dir}/eplusout.htm")] = _MINIMAL_HTML.encode("latin-1")
+
+
+@pytest.mark.asyncio
+class TestAsyncAccessors:
+    """Tests for async methods on SimulationResult."""
+
+    @pytest.fixture
+    def async_fs_setup(self, tmp_path: Path) -> tuple[InMemoryAsyncFileSystem, str]:
+        sql_path = tmp_path / "temp.sql"
+        _create_minimal_sql(sql_path)
+        async_fs = InMemoryAsyncFileSystem()
+        run_dir = "output/async_sim"
+        _populate_async_fs(async_fs, run_dir, sql_path)
+        return async_fs, run_dir
+
+    async def test_async_errors_no_file(self, tmp_path: Path) -> None:
+        report = await _make_result(tmp_path).async_errors()
+        assert report.raw_text == ""
+
+    async def test_async_errors_cached(self, tmp_path: Path) -> None:
+        result = _make_result(tmp_path)
+        r1 = await result.async_errors()
+        r2 = await result.async_errors()
+        assert r1 is r2
+
+    async def test_async_errors_with_async_fs(self, async_fs_setup: tuple[InMemoryAsyncFileSystem, str]) -> None:
+        async_fs, run_dir = async_fs_setup
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        report = await result.async_errors()
+        assert report.raw_text != ""
+
+    async def test_async_errors_with_sync_fs(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_fallback"
+        data = (FIXTURES / "sample.err").read_bytes()
+        fs.write_bytes(f"{run_dir}/eplusout.err", data)
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        report = await result.async_errors()
+        assert report.raw_text != ""
+
+    async def test_async_errors_local_file(self, result_dir: Path) -> None:
+        report = await _make_result(result_dir).async_errors()
+        assert report.raw_text != ""
+
+    async def test_async_sql_none_when_no_file(self, tmp_path: Path) -> None:
+        assert await _make_result(tmp_path).async_sql() is None
+
+    async def test_async_sql_cached_none(self, tmp_path: Path) -> None:
+        result = _make_result(tmp_path)
+        s1 = await result.async_sql()
+        s2 = await result.async_sql()
+        assert s1 is s2
+
+    async def test_async_sql_with_async_fs(self, async_fs_setup: tuple[InMemoryAsyncFileSystem, str]) -> None:
+        async_fs, run_dir = async_fs_setup
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        sql = await result.async_sql()
+        assert isinstance(sql, SQLResult)
+
+    async def test_async_sql_with_sync_fs(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_sql"
+        sql_path = tmp_path / "temp.sql"
+        _create_minimal_sql(sql_path)
+        fs.write_bytes(f"{run_dir}/eplusout.sql", sql_path.read_bytes())
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        sql = await result.async_sql()
+        assert isinstance(sql, SQLResult)
+
+    async def test_async_sql_local_file(self, result_dir: Path) -> None:
+        assert isinstance(await _make_result(result_dir).async_sql(), SQLResult)
+
+    async def test_async_variables_none_when_no_file(self, tmp_path: Path) -> None:
+        assert await _make_result(tmp_path).async_variables() is None
+
+    async def test_async_variables_cached_none(self, tmp_path: Path) -> None:
+        result = _make_result(tmp_path)
+        v1 = await result.async_variables()
+        v2 = await result.async_variables()
+        assert v1 is v2
+
+    async def test_async_variables_with_async_fs(self, async_fs_setup: tuple[InMemoryAsyncFileSystem, str]) -> None:
+        async_fs, run_dir = async_fs_setup
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        variables = await result.async_variables()
+        assert isinstance(variables, OutputVariableIndex)
+        assert len(variables.variables) == 7
+
+    async def test_async_variables_with_sync_fs(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_vars"
+        fs.write_bytes(f"{run_dir}/eplusout.rdd", (FIXTURES / "sample.rdd").read_bytes())
+        fs.write_bytes(f"{run_dir}/eplusout.mdd", (FIXTURES / "sample.mdd").read_bytes())
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        variables = await result.async_variables()
+        assert isinstance(variables, OutputVariableIndex)
+
+    async def test_async_variables_local_file(self, result_dir: Path) -> None:
+        assert isinstance(await _make_result(result_dir).async_variables(), OutputVariableIndex)
+
+    async def test_async_csv_none_when_no_file(self, tmp_path: Path) -> None:
+        assert await _make_result(tmp_path).async_csv() is None
+
+    async def test_async_csv_cached_none(self, tmp_path: Path) -> None:
+        result = _make_result(tmp_path)
+        c1 = await result.async_csv()
+        c2 = await result.async_csv()
+        assert c1 is c2
+
+    async def test_async_csv_with_async_fs(self, async_fs_setup: tuple[InMemoryAsyncFileSystem, str]) -> None:
+        async_fs, run_dir = async_fs_setup
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        csv = await result.async_csv()
+        assert isinstance(csv, CSVResult)
+
+    async def test_async_csv_with_sync_fs(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_csv"
+        fs.write_bytes(f"{run_dir}/eplusout.csv", (FIXTURES / "sample.csv").read_bytes())
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        csv = await result.async_csv()
+        assert isinstance(csv, CSVResult)
+
+    async def test_async_csv_local_file(self, result_dir: Path) -> None:
+        assert isinstance(await _make_result(result_dir).async_csv(), CSVResult)
+
+    async def test_async_html_none_when_no_file(self, tmp_path: Path) -> None:
+        assert await _make_result(tmp_path).async_html() is None
+
+    async def test_async_html_cached_none(self, tmp_path: Path) -> None:
+        result = _make_result(tmp_path)
+        h1 = await result.async_html()
+        h2 = await result.async_html()
+        assert h1 is h2
+
+    async def test_async_html_with_async_fs(self, async_fs_setup: tuple[InMemoryAsyncFileSystem, str]) -> None:
+        async_fs, run_dir = async_fs_setup
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        html = await result.async_html()
+        assert isinstance(html, HTMLResult)
+
+    async def test_async_html_with_sync_fs(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_html"
+        fs.write_text(f"{run_dir}/eplusout.htm", _MINIMAL_HTML, encoding="latin-1")
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        html = await result.async_html()
+        assert isinstance(html, HTMLResult)
+
+    async def test_async_html_local_file(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.htm").write_text(_MINIMAL_HTML, encoding="latin-1")
+        assert isinstance(await _make_result(tmp_path).async_html(), HTMLResult)
+
+    async def test_async_find_output_file_async_fs_primary(
+        self, async_fs_setup: tuple[InMemoryAsyncFileSystem, str]
+    ) -> None:
+        async_fs, run_dir = async_fs_setup
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        path = await result._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is not None
+
+    async def test_async_find_output_file_async_fs_glob_fallback(self, tmp_path: Path) -> None:
+        async_fs = InMemoryAsyncFileSystem()
+        run_dir = "output/glob_async"
+        async_fs._files[async_fs._norm(f"{run_dir}/othernameout.err")] = b"err"  # pyright: ignore[reportPrivateUsage]
+        result = SimulationResult.from_directory(run_dir, async_fs=async_fs)
+        path = await result._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is not None
+
+    async def test_async_find_output_file_async_fs_none(self) -> None:
+        async_fs = InMemoryAsyncFileSystem()
+        result = SimulationResult.from_directory("empty/async", async_fs=async_fs)
+        path = await result._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is None
+
+    async def test_async_find_output_file_sync_fs_fallback(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_find"
+        fs.write_bytes(f"{run_dir}/eplusout.err", b"err")
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        path = await result._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is not None
+
+    async def test_async_find_output_file_sync_fs_glob_fallback(self, tmp_path: Path) -> None:
+        fs = InMemoryFileSystem()
+        run_dir = "output/sync_glob"
+        fs.write_bytes(f"{run_dir}/othernameout.err", b"err")
+        result = SimulationResult.from_directory(run_dir, fs=fs)
+        path = await result._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is not None
+
+    async def test_async_find_output_file_sync_fs_none(self) -> None:
+        fs = InMemoryFileSystem()
+        result = SimulationResult.from_directory("empty/sync", fs=fs)
+        path = await result._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is None
+
+    async def test_async_find_output_file_local_primary(self, tmp_path: Path) -> None:
+        (tmp_path / "eplusout.err").write_text("err content")
+        path = await _make_result(tmp_path)._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is not None
+
+    async def test_async_find_output_file_local_scan_fallback(self, tmp_path: Path) -> None:
+        (tmp_path / "othernameout.err").write_text("err content")
+        path = await _make_result(tmp_path)._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is not None
+
+    async def test_async_find_output_file_local_none(self, tmp_path: Path) -> None:
+        path = await _make_result(tmp_path)._async_find_output_file(".err")  # pyright: ignore[reportPrivateUsage]
+        assert path is None


### PR DESCRIPTION
## Summary
- Adds tests for `SimulationResult` container covering all missing branches and error paths
- Achieves 100% coverage for `src/idfkit/simulation/result.py`

## Test plan
- [ ] `uv run pytest tests/test_simulation_result.py -v`
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)