### PR TITLE
Fix: strengthen weak test assertions found in coverage audit

### DIFF
--- a/tests/schedules/test_day.py
+++ b/tests/schedules/test_day.py
@@ -160,11 +160,17 @@ class TestEvaluateDayInterval:
         assert result == 0.0
 
     def test_interpolation(self, interval_schedule: MagicMock) -> None:
-        """Test interpolation between values."""
-        # At 8am boundary with interpolation
+        """Test interpolation at the 08:00 boundary.
+
+        At exactly 08:00 the first interval (until 08:00, value=0.0) is closed
+        (boundary is exclusive: current < until is False at equality).  We fall
+        into the second interval [08:00, 18:00) with prev_value=0.0.
+        fraction = (480-480)/(1080-480) = 0.0, so interpolation returns 0.0.
+        Without interpolation the step function would return 1.0 (the second
+        interval's value), confirming interpolation is active.
+        """
         result = evaluate_day_interval(interval_schedule, datetime(2024, 1, 1, 8, 0), Interpolation.AVERAGE)
-        # At exactly 8:00, should be interpolated
-        assert 0.0 <= result <= 1.0
+        assert result == 0.0
 
 
 class TestEvaluateDayList:

--- a/tests/test_compat_cli.py
+++ b/tests/test_compat_cli.py
@@ -249,8 +249,8 @@ class TestCLI:
                 "24.2",
             ])
         # Exit 0 = no issues, Exit 1 = issues found
-        # Zone/Material are stable so we expect 0
-        assert exc_info.value.code in (0, 1)
+        # Zone/Material are stable across 24.1→24.2 so we expect 0
+        assert exc_info.value.code == 0
 
     def test_cli_json_output(self, simple_script_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """CLI --json produces valid JSON output."""

--- a/tests/test_compat_extract.py
+++ b/tests/test_compat_extract.py
@@ -48,6 +48,7 @@ class TestExtractAddCalls:
 
         assert len(choices) == 1
         assert choices[0].value == "Yes"
+        assert choices[0].obj_type == "SimulationControl"
         assert choices[0].field_name == "run_simulation_for_sizing_periods"
 
     def test_add_no_string_arg(self) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -99,8 +99,8 @@ class TestValidateDocument:
 
     def test_validate_simple_doc(self, simple_doc: IDFDocument) -> None:
         result = validate_document(simple_doc)
-        # May have warnings but should not crash
-        assert isinstance(result, ValidationResult)
+        # simple_doc has valid references and required fields — no errors expected
+        assert result.errors == []
 
     def test_validate_no_schema(self) -> None:
         doc = IDFDocument()  # No schema loaded
@@ -111,11 +111,14 @@ class TestValidateDocument:
 
     def test_validate_specific_object_types(self, simple_doc: IDFDocument) -> None:
         result = validate_document(simple_doc, object_types=["Zone"])
-        assert isinstance(result, ValidationResult)
+        # Scoping to Zone only: no errors expected for a well-formed zone
+        assert result.errors == []
 
     def test_validate_check_references_disabled(self, simple_doc: IDFDocument) -> None:
         result = validate_document(simple_doc, check_references=False)
-        assert isinstance(result, ValidationResult)
+        # With reference checking disabled, no E009 errors should appear
+        ref_errors = [e for e in result.errors if e.code == "E009"]
+        assert ref_errors == []
 
     def test_validate_all_checks_disabled(self, simple_doc: IDFDocument) -> None:
         result = validate_document(
@@ -125,7 +128,8 @@ class TestValidateDocument:
             check_types=False,
             check_ranges=False,
         )
-        assert isinstance(result, ValidationResult)
+        # With every check disabled, no errors should be produced
+        assert result.errors == []
 
 
 class TestValidateReferences:
@@ -149,8 +153,9 @@ class TestValidateReferences:
 
     def test_valid_references_pass(self, simple_doc: IDFDocument) -> None:
         result = validate_document(simple_doc, check_references=True)
-        # TestConstruction -> TestMaterial is valid, TestWall -> TestZone is valid
-        assert isinstance(result, ValidationResult)
+        # TestConstruction→TestMaterial and TestWall→TestZone are all valid references
+        ref_errors = [e for e in result.errors if e.code == "E009"]
+        assert ref_errors == []
 
 
 class TestValidateSingletons:


### PR DESCRIPTION
## Summary

AI-generated coverage tests were written to hit lines rather than verify behavior. Four patterns found and fixed:

- **`test_day.py` — `test_interpolation`**: The loose `assert 0.0 <= result <= 1.0` would pass whether interpolation was enabled or not. Replaced with `assert result == 0.0`, which is the precise value produced by interpolation at the 08:00 boundary (`fraction=0`, previous interval's value) and differs from the step-function result (1.0).
- **`test_compat_cli.py` — `test_cli_no_issues_exit_0`**: Comment said "expect 0" but asserted `code in (0, 1)`, accepting a broken CLI that always exits 1. Fixed to `== 0`.
- **`test_compat_extract.py` — `test_add_with_dict_no_name`**: Missing `obj_type` assertion that every sibling test includes. Added `assert choices[0].obj_type == "SimulationControl"`.
- **`test_validation.py`** (4 tests): Replaced `isinstance(result, ValidationResult)` checks — which test nothing about validation outcomes — with `result.errors == []` and targeted E009 reference-error checks.

The fix for the day-list interpolation test (`test_interpolate_to_timestep_average`, evaluating at 0:30 inside an interval with value=0.0 where both interpolated and non-interpolated results are identical) is in PR #111.

## Test plan
- [ ] All 9 modified tests pass with the stricter assertions
- [ ] `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)