### PR TITLE
fix: isolate migration CWD per step to fix concurrent audit.out collision

### DIFF
--- a/src/idfkit/migration/async_subprocess_backend.py
+++ b/src/idfkit/migration/async_subprocess_backend.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from ..exceptions import MigrationError
 from .protocol import MigrationStepResult
-from .subprocess_backend import DEFAULT_STEP_TIMEOUT, binary_candidates, collect_audit_text
+from .subprocess_backend import DEFAULT_STEP_TIMEOUT, binary_candidates, collect_audit_text, stage_idd_symlinks
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class AsyncSubprocessMigrator:
         binary = self.locate_binary(from_version, to_version)
 
         await asyncio.to_thread(work_dir.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(stage_idd_symlinks, self.version_updater_dir, work_dir)
         input_idf = work_dir / "in.idf"
         await asyncio.to_thread(input_idf.write_text, idf_text, "latin-1")
 
@@ -58,7 +59,7 @@ class AsyncSubprocessMigrator:
                 str(input_idf),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=str(self.version_updater_dir),
+                cwd=str(work_dir),
             )
         except OSError as exc:
             msg = f"Failed to start transition binary: {exc}"

--- a/src/idfkit/migration/subprocess_backend.py
+++ b/src/idfkit/migration/subprocess_backend.py
@@ -2,14 +2,16 @@
 
 The binaries live in ``PreProcess/IDFVersionUpdater`` inside an EnergyPlus
 installation. Each binary takes a single IDF file as its command-line argument,
-reads the sibling ``V{from}-Energy+.idd`` file, and writes the migrated IDF
-back to the same path (moving the original to ``<name>.idfold``).
+reads the sibling ``V{from}-Energy+.idd`` file (resolved relative to the
+binary's own location), and writes the migrated IDF back to the same path
+(moving the original to ``<name>.idfold``).
 
-The binary must be run with ``cwd`` set to the ``IDFVersionUpdater`` directory
-so it can locate its ``VX-Y-Z-Energy+.idd`` companion; we therefore stage the
-input IDF inside a temporary subdirectory and invoke the binary from there
-using an absolute path to the binary (matching how ``IDFVersionUpdater.app``
-launches them).
+Each step runs with ``cwd`` set to the caller-provided ``work_dir`` — a
+per-step temporary directory — so that ``audit.out`` and other side-effects
+land in isolation. This allows concurrent migrations against the same
+EnergyPlus install without file collisions. The companion ``V*-Energy+.idd``
+files are symlinked into ``work_dir`` before execution so the Fortran binary
+can still find them via its CWD-relative lookup.
 """
 
 from __future__ import annotations
@@ -54,6 +56,7 @@ class SubprocessMigrator:
         binary = self.locate_binary(from_version, to_version)
 
         work_dir.mkdir(parents=True, exist_ok=True)
+        stage_idd_symlinks(self.version_updater_dir, work_dir)
         input_idf = work_dir / "in.idf"
         input_idf.write_text(idf_text, encoding="latin-1")
 
@@ -63,7 +66,7 @@ class SubprocessMigrator:
                 capture_output=True,
                 text=True,
                 timeout=self.step_timeout,
-                cwd=str(self.version_updater_dir),
+                cwd=str(work_dir),
                 check=False,
             )
         except subprocess.TimeoutExpired as exc:
@@ -131,6 +134,19 @@ class SubprocessMigrator:
             raise MigrationError(msg, from_version=from_version, to_version=to_version)
         msg = f"No transition binary found. Tried: {', '.join(candidates)}"
         raise MigrationError(msg, from_version=from_version, to_version=to_version)
+
+
+def stage_idd_symlinks(version_updater_dir: Path, work_dir: Path) -> None:
+    """Symlink ``V*-Energy+.idd`` files from *version_updater_dir* into *work_dir*.
+
+    The Fortran transition binaries read their companion IDD relative to CWD.
+    By symlinking the IDDs into the per-step work directory we can set
+    ``cwd=work_dir``, isolating ``audit.out`` writes between concurrent runs.
+    """
+    for idd in version_updater_dir.glob("V*-Energy+.idd"):
+        link = work_dir / idd.name
+        if not link.exists():
+            link.symlink_to(idd)
 
 
 def binary_candidates(

--- a/tests/test_migration_subprocess_backend.py
+++ b/tests/test_migration_subprocess_backend.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from idfkit.exceptions import MigrationError
+from idfkit.migration.async_subprocess_backend import AsyncSubprocessMigrator
 from idfkit.migration.subprocess_backend import SubprocessMigrator, binary_candidates
 
 
@@ -94,6 +95,39 @@ class TestSubprocessMigrator:
         assert result.stdout == "ok"
 
     @patch("idfkit.migration.subprocess_backend.subprocess.run")
+    def test_cwd_is_work_dir_not_updater_dir(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        updater_dir: Path,
+    ) -> None:
+        """Subprocess must run with cwd=work_dir so concurrent migrations don't collide."""
+        binary = updater_dir / "Transition-V24-1-0-to-V24-2-0"
+        binary.touch()
+        binary.chmod(0o755)
+
+        work = tmp_path / "work"
+
+        def _fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+            Path(cmd[1]).write_text("Version,24.2;\n", encoding="latin-1")
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = ""
+            proc.stderr = ""
+            return proc
+
+        mock_run.side_effect = _fake_run
+
+        migrator = SubprocessMigrator(version_updater_dir=updater_dir)
+        migrator.migrate_step("Version,24.1;\n", (24, 1, 0), (24, 2, 0), work_dir=work)
+
+        _, call_kwargs = mock_run.call_args
+        assert call_kwargs["cwd"] == str(work), (
+            f"Expected cwd={work}, got cwd={call_kwargs['cwd']}. "
+            "The subprocess must run in the isolated work_dir, not the shared version_updater_dir."
+        )
+
+    @patch("idfkit.migration.subprocess_backend.subprocess.run")
     def test_nonzero_exit_raises(
         self,
         mock_run: MagicMock,
@@ -137,3 +171,44 @@ class TestSubprocessMigrator:
                 (24, 2, 0),
                 work_dir=tmp_path / "work",
             )
+
+
+class TestAsyncSubprocessMigratorCwd:
+    @pytest.fixture
+    def updater_dir(self, tmp_path: Path) -> Path:
+        d = tmp_path / "IDFVersionUpdater"
+        d.mkdir()
+        return d
+
+    @pytest.mark.asyncio
+    async def test_cwd_is_work_dir_not_updater_dir(
+        self,
+        tmp_path: Path,
+        updater_dir: Path,
+    ) -> None:
+        """Async subprocess must run with cwd=work_dir so concurrent migrations don't collide."""
+        binary = updater_dir / "Transition-V24-1-0-to-V24-2-0"
+        binary.touch()
+        binary.chmod(0o755)
+
+        work = tmp_path / "work"
+        captured_cwd: list[str] = []
+
+        async def _fake_exec(*args: object, **kwargs: object) -> MagicMock:
+            captured_cwd.append(str(kwargs.get("cwd", "")))
+            # Write the migrated file so the backend finds it.
+            (work / "in.idf").write_text("Version,24.2;\n", encoding="latin-1")
+            proc = AsyncMock()
+            proc.communicate.return_value = (b"ok", b"")
+            proc.returncode = 0
+            proc.kill = MagicMock()
+            proc.wait = AsyncMock()
+            return proc
+
+        with patch("idfkit.migration.async_subprocess_backend.asyncio.create_subprocess_exec", side_effect=_fake_exec):
+            migrator = AsyncSubprocessMigrator(version_updater_dir=updater_dir)
+            await migrator.migrate_step("Version,24.1;\n", (24, 1, 0), (24, 2, 0), work_dir=work)
+
+        assert captured_cwd[0] == str(work), (
+            f"Expected cwd={work}, got cwd={captured_cwd[0]}. The async subprocess must run in the isolated work_dir."
+        )


### PR DESCRIPTION
## Summary

Fixes #129 — concurrent migrations against the same EnergyPlus install collided on `audit.out` because both Fortran transition binaries wrote to the shared `version_updater_dir`.

- Each step now runs with `cwd=work_dir` (its per-step isolated temp directory) instead of the shared `version_updater_dir`
- New `stage_idd_symlinks()` helper symlinks the `V*-Energy+.idd` companion files into `work_dir` so the binary can still resolve them via its CWD-relative lookup
- As a bonus, `collect_audit_text(work_dir)` now actually finds audit files — the binary was previously writing them outside `work_dir`

## Test plan

- [x] New unit tests assert `cwd=work_dir` for both `SubprocessMigrator` and `AsyncSubprocessMigrator`
- [x] Existing unit tests continue to pass (10/10 in backend test file)
- [x] Full test suite green (2971 passed, 1 skipped)
- [x] `make check` clean (ruff, pyright, deptry)
- [x] Real end-to-end migration verified: `(22, 1, 0) -> (25, 2, 0)` across 7 steps, all audit text captured
- [x] Two concurrent `async_migrate()` calls on the same EnergyPlus install both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)