### PR TITLE
feat(cli): add `idfkit migrate` subcommand

### DIFF
--- a/docs/concepts/version-compatibility.md
+++ b/docs/concepts/version-compatibility.md
@@ -14,9 +14,9 @@ different EnergyPlus versions.
     *statically* — it tells you which lines of your code reference object
     types or choice values that won't exist in another EnergyPlus version.
     To actually upgrade an existing IDF model, see
-    [Migrating Versions](../simulation/migrating-versions.md), which uses
-    `idfkit.migrate()` to forward-migrate models through the
-    `IDFVersionUpdater` transition binaries.
+    [Migrating Versions](../simulation/migrating-versions.md), which exposes
+    the sibling `idfkit migrate` CLI and the `idfkit.migrate()` Python
+    API — both drive the `IDFVersionUpdater` transition binaries.
 
 ## What it detects
 

--- a/docs/simulation/migrating-versions.md
+++ b/docs/simulation/migrating-versions.md
@@ -42,6 +42,50 @@ exposes:
 | `success` | `True` only when every step succeeded. |
 | `summary()` | Short human-readable summary suitable for logs or CLI. |
 
+## CLI
+
+The `idfkit migrate` subcommand is a thin wrapper over `migrate()` for shell
+users. It loads the input IDF, forward-migrates it through the installed
+`IDFVersionUpdater` transition binaries, and writes the result to disk.
+
+### Basic usage
+
+```bash
+# Migrate to the latest supported version; writes old-v25-2-0.idf next to input
+idfkit migrate old.idf
+
+# Explicit target and output path
+idfkit migrate old.idf --to 25.2 -o new.idf
+
+# Machine-readable report (suppresses stderr progress output)
+idfkit migrate old.idf --to 25.2 --json
+```
+
+When `--to` is omitted the target is the latest supported version. When
+`--output` is omitted the result is written to `<stem>-v<major>-<minor>-<patch>.idf`
+next to the input.
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Migration succeeded (or source version equals target — no-op) |
+| `1` | Migration runtime failure (a transition binary exited non-zero) |
+| `2` | Argument or configuration error (bad version, missing input, EnergyPlus not found) |
+
+### Flag reference
+
+| Flag | Description |
+|------|-------------|
+| `INPUT` | Path to the source IDF file (positional, required) |
+| `-o`, `--output OUTPUT` | Output IDF path. Defaults to `<stem>-v<target>.idf` next to the input. |
+| `--to VERSION` | Target EnergyPlus version (e.g. `25.2`). Defaults to the latest supported. |
+| `--energyplus PATH` | Path to the EnergyPlus install or executable. Auto-discovered via `$ENERGYPLUS_DIR`, `PATH`, and platform defaults when omitted. |
+| `--work-dir DIR` | Directory in which to stage per-step transition output. Defaults to a temporary directory. |
+| `--keep-work-dir` | Preserve intermediate files for inspection (only meaningful with the default temp directory). |
+| `--json` | Emit a JSON report on stdout instead of the human-readable summary. Also suppresses stderr progress output. |
+| `-q`, `--quiet` | Suppress progress output. |
+
 ## Transparent Migration During `simulate()`
 
 When you only want a simulation result, pass `auto_migrate=True` and
@@ -81,6 +125,6 @@ which transition broke.
 ## See Also
 
 - [Migration API](../api/migration.md) — full reference for `migrate`, `MigrationReport`, and the `Migrator` protocol.
-- [Version Compatibility](../concepts/version-compatibility.md) — the *static* `idfkit check` linter for catching cross-version breakage in your code before you migrate.
+- [Version Compatibility](../concepts/version-compatibility.md) — the sibling `idfkit check` subcommand for *statically* linting your Python code for cross-version breakage before you migrate.
 - [Running Simulations](running.md) — full `simulate()` parameter reference.
 - [Error Handling](errors.md) — handling `VersionMismatchError` from `simulate()`.

--- a/docs/troubleshooting/errors.md
+++ b/docs/troubleshooting/errors.md
@@ -263,6 +263,11 @@ from the installed EnergyPlus, and `auto_migrate` is `False` (the default).
    result = simulate(report.migrated_model, weather)
    ```
 
+3. From the shell (no Python session required):
+   ```bash
+   idfkit migrate path/to/model.idf --to 25.2
+   ```
+
 !!! warning "Backward migration is not supported"
     EnergyPlus ships no reverse transition binaries, so a model *newer*
     than the installed EnergyPlus cannot be downgraded. Install a newer

--- a/src/idfkit/compat/_cli.py
+++ b/src/idfkit/compat/_cli.py
@@ -1,17 +1,19 @@
-"""CLI entry point for the idfkit compatibility linter.
+"""CLI entry points for idfkit.
 
-The ``idfkit check`` command statically lints Python source files that use
-idfkit and reports EnergyPlus object types or enumerated choice values that
-differ between schema versions.
+Subcommands:
+
+- ``idfkit check`` — statically lint Python source files that use idfkit and
+  report object types or enumerated choice values that differ between
+  EnergyPlus schema versions.
+- ``idfkit migrate`` — forward-migrate an IDF model to a newer EnergyPlus
+  version via the installed ``IDFVersionUpdater`` transition binaries.
 
 Usage examples::
 
     idfkit check script.py --from 24.2 --to 25.1
-    idfkit check script.py --targets 24.2,25.1,25.2
     idfkit check script.py --targets 24.2,25.1,25.2 --json
-    idfkit check script.py --from 24.2 --to 25.1 --sarif
-    idfkit check script.py --from 24.2 --to 25.1 --select C001
-    idfkit check script.py --from 24.2 --to 25.1 --group "Thermal Zones and Surfaces"
+    idfkit migrate old.idf --to 25.2
+    idfkit migrate old.idf --output new.idf --to 25.2 --json
 """
 
 from __future__ import annotations
@@ -19,12 +21,21 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable
+from dataclasses import asdict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from ..versions import ENERGYPLUS_VERSIONS, version_string
+from ..exceptions import EnergyPlusNotFoundError, MigrationError, UnsupportedVersionError
+from ..migration import MigrationProgress, MigrationReport, migrate
+from ..versions import ENERGYPLUS_VERSIONS, LATEST_VERSION, version_string
 from ._checker import check_compatibility, resolve_version
 from ._models import DIAGNOSTIC_CODES, CompatSeverity, Diagnostic
 from ._sarif import format_sarif
+
+if TYPE_CHECKING:
+    from ..document import IDFDocument
+    from ..simulation.config import EnergyPlusConfig
 
 
 def _parse_version_spec(spec: str) -> tuple[int, int, int]:
@@ -165,6 +176,75 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Minimum severity level to report (warning or error). Default: report all.",
     )
 
+    migrate_cmd = sub.add_parser(
+        "migrate",
+        help="Forward-migrate an IDF model to a newer EnergyPlus version",
+        description=(
+            "Forward-migrate an IDF model through EnergyPlus IDFVersionUpdater "
+            "transition binaries. Requires a local EnergyPlus installation."
+        ),
+    )
+    migrate_cmd.add_argument(
+        "input",
+        metavar="INPUT",
+        help="Path to the source IDF file",
+    )
+    migrate_cmd.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        default=None,
+        metavar="OUTPUT",
+        help="Output IDF path. Defaults to '<input_stem>-v<target>.idf' next to the input.",
+    )
+    migrate_cmd.add_argument(
+        "--to",
+        dest="to_version",
+        type=_parse_version_spec,
+        default=None,
+        metavar="VERSION",
+        help=f"Target EnergyPlus version (e.g. 25.2). Defaults to the latest supported ({version_string(LATEST_VERSION)}).",
+    )
+    migrate_cmd.add_argument(
+        "--energyplus",
+        dest="energyplus_path",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to the EnergyPlus installation directory or executable. "
+            "When omitted, idfkit auto-discovers via $ENERGYPLUS_DIR, PATH, and platform defaults."
+        ),
+    )
+    migrate_cmd.add_argument(
+        "--work-dir",
+        dest="work_dir",
+        default=None,
+        metavar="DIR",
+        help="Directory in which to stage per-step transition output. Defaults to a temporary directory.",
+    )
+    migrate_cmd.add_argument(
+        "--keep-work-dir",
+        dest="keep_work_dir",
+        action="store_true",
+        default=False,
+        help="Preserve intermediate files for inspection (only meaningful for the default temp directory).",
+    )
+    migrate_cmd.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        default=False,
+        help="Emit a JSON report on stdout instead of a human-readable summary.",
+    )
+    migrate_cmd.add_argument(
+        "-q",
+        "--quiet",
+        dest="quiet",
+        action="store_true",
+        default=False,
+        help="Suppress progress output (final report is still written unless --json is off).",
+    )
+
     return top
 
 
@@ -276,6 +356,8 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "check":
         _run_check(args)
+    elif args.command == "migrate":
+        _run_migrate(args)
 
 
 def _run_check(args: argparse.Namespace) -> None:
@@ -341,3 +423,180 @@ def _run_check(args: argparse.Namespace) -> None:
 
     # Exit code: 1 if any issues, 0 otherwise
     sys.exit(1 if all_diagnostics else 0)
+
+
+def _default_output_path(input_path: Path, target: tuple[int, int, int]) -> Path:
+    """Compute the default output path next to *input_path*."""
+    tag = f"v{target[0]}-{target[1]}-{target[2]}"
+    return input_path.with_name(f"{input_path.stem}-{tag}{input_path.suffix or '.idf'}")
+
+
+def _progress_printer() -> Callable[[MigrationProgress], None]:
+    """Return a callable that prints migration progress events to stderr."""
+
+    def _print(event: MigrationProgress) -> None:
+        prefix = f"[{event.phase}]"
+        if event.step_index is not None and event.total_steps:
+            prefix += f" {event.step_index + 1}/{event.total_steps}"
+        print(f"{prefix} {event.message}", file=sys.stderr)
+
+    return _print
+
+
+def _format_migrate_json(report: MigrationReport, *, input_path: Path, output_path: Path | None) -> str:
+    """Serialize a MigrationReport for ``--json`` output."""
+    payload: dict[str, object] = {
+        "input": str(input_path),
+        "output": str(output_path) if output_path is not None else None,
+        "success": report.success,
+        "source_version": version_string(report.source_version),
+        "target_version": version_string(report.target_version),
+        "requested_target": version_string(report.requested_target),
+        "steps": [
+            {
+                "from": version_string(s.from_version),
+                "to": version_string(s.to_version),
+                "success": s.success,
+                "runtime_seconds": s.runtime_seconds,
+                "binary": str(s.binary) if s.binary is not None else None,
+            }
+            for s in report.steps
+        ],
+        "diff": {
+            "added_object_types": list(report.diff.added_object_types),
+            "removed_object_types": list(report.diff.removed_object_types),
+            "object_count_delta": dict(report.diff.object_count_delta),
+            "field_changes": {k: asdict(v) for k, v in report.diff.field_changes.items()},
+        },
+    }
+    return json.dumps(payload, indent=2)
+
+
+def _resolve_migrate_target(spec: tuple[int, int, int] | None) -> tuple[int, int, int]:
+    """Resolve the requested target to a bundled schema version, exiting on failure."""
+    target = spec if spec is not None else LATEST_VERSION
+    try:
+        return resolve_version(target)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _invoke_migrate(
+    *,
+    model: IDFDocument,
+    target: tuple[int, int, int],
+    energyplus: EnergyPlusConfig | None,
+    on_progress: Callable[[MigrationProgress], None] | None,
+    work_dir: str | None,
+    keep_work_dir: bool,
+) -> MigrationReport:
+    """Call ``migrate`` and translate raised exceptions into CLI exits."""
+    try:
+        return migrate(
+            model,
+            target_version=target,
+            energyplus=energyplus,
+            on_progress=on_progress,
+            work_dir=work_dir,
+            keep_work_dir=keep_work_dir,
+        )
+    except UnsupportedVersionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except EnergyPlusNotFoundError as exc:
+        print(f"error: no EnergyPlus installation found ({exc})", file=sys.stderr)
+        sys.exit(2)
+    except MigrationError as exc:
+        print(f"error: migration failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _write_migrate_output(
+    report: MigrationReport,
+    *,
+    input_path: Path,
+    fallback_model: IDFDocument,
+    resolved_target: tuple[int, int, int],
+    explicit_output: str | None,
+) -> Path | None:
+    """Write the migrated IDF to disk and return the resulting path, if any."""
+    from ..writers import write_idf
+
+    if report.migrated_model is not None:
+        output_path = Path(explicit_output) if explicit_output else _default_output_path(input_path, resolved_target)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_idf(report.migrated_model, output_path)
+        return output_path
+    if explicit_output is not None:
+        # No-op migration: still honor an explicit --output by copying the input model.
+        output_path = Path(explicit_output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_idf(fallback_model, output_path)
+        return output_path
+    return None
+
+
+def _load_source_idf(input_path: Path) -> IDFDocument:
+    """Load the source IDF, exiting on any parse/IO error."""
+    from .. import load_idf
+
+    try:
+        return load_idf(str(input_path))
+    except Exception as exc:
+        print(f"error: failed to load {input_path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _resolve_energyplus_arg(path_arg: str | None) -> EnergyPlusConfig | None:
+    """Resolve an optional ``--energyplus`` path into a config, exiting on failure."""
+    if path_arg is None:
+        return None
+    from ..simulation.config import find_energyplus
+
+    try:
+        return find_energyplus(path=path_arg)
+    except EnergyPlusNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _run_migrate(args: argparse.Namespace) -> None:
+    """Execute the ``migrate`` subcommand."""
+    input_path = Path(args.input)
+    if not input_path.is_file():
+        print(f"error: file not found: {input_path}", file=sys.stderr)
+        sys.exit(2)
+
+    resolved_target = _resolve_migrate_target(args.to_version)
+    model = _load_source_idf(input_path)
+    energyplus = _resolve_energyplus_arg(args.energyplus_path)
+    on_progress = None if (args.quiet or args.json_output) else _progress_printer()
+
+    report = _invoke_migrate(
+        model=model,
+        target=resolved_target,
+        energyplus=energyplus,
+        on_progress=on_progress,
+        work_dir=args.work_dir,
+        keep_work_dir=args.keep_work_dir,
+    )
+
+    output_path = _write_migrate_output(
+        report,
+        input_path=input_path,
+        fallback_model=model,
+        resolved_target=resolved_target,
+        explicit_output=args.output,
+    )
+
+    if args.json_output:
+        print(_format_migrate_json(report, input_path=input_path, output_path=output_path))
+    elif not args.quiet:
+        print(report.summary())
+        if output_path is not None:
+            print(f"Wrote: {output_path}")
+        elif report.migrated_model is None:
+            print("No migration needed (source equals target).")
+
+    sys.exit(0 if report.success else 1)

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -1,0 +1,310 @@
+"""Tests for the ``idfkit migrate`` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import idfkit.compat._cli as cli_module
+from idfkit import load_idf, new_document, write_idf
+from idfkit.compat._cli import main
+from idfkit.exceptions import EnergyPlusNotFoundError, MigrationError, UnsupportedVersionError
+from idfkit.migration.report import FieldDelta, MigrationDiff, MigrationReport, MigrationStep
+from idfkit.versions import LATEST_VERSION, version_string
+
+
+@pytest.fixture
+def source_idf(tmp_path: Path) -> Path:
+    """A minimal IDF file at v24.1.0 on disk."""
+    doc = new_document(version=(24, 1, 0))
+    path = tmp_path / "source.idf"
+    write_idf(doc, path)
+    return path
+
+
+def _make_fake_migrate(
+    *,
+    target: tuple[int, int, int],
+    source: tuple[int, int, int] = (24, 1, 0),
+    success: bool = True,
+    raise_exc: BaseException | None = None,
+    record: dict[str, Any] | None = None,
+) -> Any:
+    """Build a stand-in for ``idfkit.migration.migrate`` that returns a canned report.
+
+    When *raise_exc* is supplied the fake raises it instead of returning.
+    When *record* is supplied the call kwargs are written into it for inspection.
+    """
+
+    def fake_migrate(model: Any, **kwargs: Any) -> MigrationReport:
+        if record is not None:
+            record["model"] = model
+            record["kwargs"] = kwargs
+        if raise_exc is not None:
+            raise raise_exc
+        migrated = new_document(version=target) if target != source else None
+        step = MigrationStep(
+            from_version=source,
+            to_version=target,
+            success=success,
+            stdout="ok",
+            stderr="",
+            runtime_seconds=0.01,
+        )
+        diff = MigrationDiff(
+            added_object_types=("NewType",),
+            removed_object_types=(),
+            object_count_delta={"Building": 0},
+            field_changes={"Building": FieldDelta(added=("new_field",), removed=())},
+        )
+        return MigrationReport(
+            migrated_model=migrated,
+            source_version=source,
+            target_version=target,
+            requested_target=target,
+            steps=() if target == source else (step,),
+            diff=diff if target != source else MigrationDiff(),
+        )
+
+    return fake_migrate
+
+
+class TestCliMigrateDefaults:
+    """Argument resolution: defaults for --to and --output."""
+
+    def test_defaults_to_latest_version(
+        self,
+        source_idf: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        record: dict[str, Any] = {}
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(target=LATEST_VERSION, record=record),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf)])
+
+        assert exc.value.code == 0
+        assert record["kwargs"]["target_version"] == LATEST_VERSION
+
+        expected = source_idf.with_name(f"source-v{LATEST_VERSION[0]}-{LATEST_VERSION[1]}-{LATEST_VERSION[2]}.idf")
+        assert expected.is_file()
+        captured = capsys.readouterr()
+        assert "Wrote:" in captured.out
+        assert str(expected) in captured.out
+
+    def test_explicit_to_and_output(
+        self,
+        source_idf: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(target=(25, 2, 0)),
+        )
+        out = tmp_path / "nested" / "out.idf"
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "25.2", "--output", str(out)])
+
+        assert exc.value.code == 0
+        assert out.is_file()
+        # Sanity-check the output parses at the new version.
+        migrated = load_idf(str(out))
+        assert migrated.version == (25, 2, 0)
+
+    def test_noop_does_not_write_without_explicit_output(
+        self,
+        source_idf: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(target=(24, 1, 0), source=(24, 1, 0)),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "24.1"])
+
+        assert exc.value.code == 0
+        # No default output file should appear next to the source.
+        stragglers = [p for p in tmp_path.iterdir() if p != source_idf]
+        assert stragglers == []
+        out = capsys.readouterr().out
+        assert "No migration needed" in out
+
+    def test_noop_with_explicit_output_copies_input(
+        self,
+        source_idf: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(target=(24, 1, 0), source=(24, 1, 0)),
+        )
+        out = tmp_path / "copy.idf"
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "24.1", "--output", str(out)])
+
+        assert exc.value.code == 0
+        assert out.is_file()
+
+
+class TestCliMigrateJson:
+    """``--json`` produces a machine-readable report."""
+
+    def test_json_payload_shape(
+        self,
+        source_idf: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(target=(25, 2, 0)),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "25.2", "--json"])
+
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        # With --json, stderr progress output should be suppressed.
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["success"] is True
+        assert payload["source_version"] == "24.1.0"
+        assert payload["target_version"] == "25.2.0"
+        assert payload["requested_target"] == "25.2.0"
+        assert payload["input"] == str(source_idf)
+        assert payload["output"] is not None
+        assert len(payload["steps"]) == 1
+        assert payload["steps"][0]["from"] == "24.1.0"
+        assert payload["steps"][0]["to"] == "25.2.0"
+        assert payload["diff"]["added_object_types"] == ["NewType"]
+        assert payload["diff"]["field_changes"]["Building"] == {
+            "added": ["new_field"],
+            "removed": [],
+        }
+
+    def test_quiet_suppresses_progress(
+        self,
+        source_idf: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        record: dict[str, Any] = {}
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(target=(25, 2, 0), record=record),
+        )
+
+        with pytest.raises(SystemExit):
+            main(["migrate", str(source_idf), "--to", "25.2", "--quiet"])
+
+        assert record["kwargs"]["on_progress"] is None
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+
+class TestCliMigrateErrors:
+    """Failure modes surface with the right exit codes and messages."""
+
+    def test_input_not_found(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", "/nonexistent/input.idf", "--to", "25.2"])
+
+        assert exc.value.code == 2
+        assert "file not found" in capsys.readouterr().err
+
+    def test_unsupported_target_version(
+        self,
+        source_idf: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(
+                target=(24, 1, 0),
+                raise_exc=UnsupportedVersionError((99, 0, 0), ((24, 1, 0),)),
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "24.1"])
+
+        assert exc.value.code == 2
+        assert "error:" in capsys.readouterr().err
+
+    def test_energyplus_not_found(
+        self,
+        source_idf: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(
+                target=(25, 2, 0),
+                raise_exc=EnergyPlusNotFoundError(["/nowhere"]),
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "25.2"])
+
+        assert exc.value.code == 2
+        assert "no EnergyPlus installation found" in capsys.readouterr().err
+
+    def test_migration_error_exits_1(
+        self,
+        source_idf: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(
+            cli_module,
+            "migrate",
+            _make_fake_migrate(
+                target=(25, 2, 0),
+                raise_exc=MigrationError(
+                    "boom",
+                    from_version=(24, 1, 0),
+                    to_version=(24, 2, 0),
+                    exit_code=1,
+                    stderr="",
+                    completed_steps=(),
+                ),
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["migrate", str(source_idf), "--to", "25.2"])
+
+        assert exc.value.code == 1
+        assert "migration failed" in capsys.readouterr().err
+
+
+def test_target_version_string_roundtrip() -> None:
+    """Sanity check: version_string is stable for tuples used in payload fields."""
+    assert version_string((25, 2, 0)) == "25.2.0"


### PR DESCRIPTION
## Summary
- Adds `idfkit migrate` subcommand that wraps the existing `idfkit.migration.migrate` orchestrator so IDF models can be forward-migrated between EnergyPlus versions from the shell.
- Sensible defaults: target = latest supported version (25.2.0), output = `<stem>-v<target>.idf` next to input. Supports `--to`, `--output`, `--energyplus`, `--work-dir`, `--keep-work-dir`, `--json`, `--quiet`.
- Exit codes: `0` success, `1` migration runtime failure, `2` argument/configuration error.

## Usage
```bash
idfkit migrate old.idf                         # to latest, writes old-v25-2-0.idf
idfkit migrate old.idf --to 25.2 -o new.idf
idfkit migrate old.idf --to 25.2 --json        # machine-readable report
idfkit migrate old.idf --energyplus /path/to/EnergyPlus --keep-work-dir
```

## Notes
- The entry point (`idfkit = "idfkit.compat._cli:main"`) is unchanged; `migrate` lives next to `check` in the same dispatch. Worth renaming the module to `idfkit._cli` in a follow-up now that it hosts more than the compat linter.
- No new dependencies. The migration runtime still requires a local EnergyPlus installation (unchanged from the Python API).

## Test plan
- [x] `make check` (ruff, pyright strict, deptry, pre-commit)
- [x] `make test` (2982 passed, 1 skipped)
- [x] 11 new tests in `tests/test_cli_migrate.py` cover default/explicit `--to`, default/explicit `--output`, no-op source==target, `--json` payload shape, `--quiet` suppression, missing input, unsupported version, EnergyPlus-not-found, and `MigrationError` → exit 1
- [x] Manual smoke test: `uv run idfkit migrate --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)