### PR TITLE
feat(cli): add `idfkit tmy` subcommand for TMYx weather data

### DIFF
--- a/src/idfkit/compat/_cli.py
+++ b/src/idfkit/compat/_cli.py
@@ -7,6 +7,9 @@ Subcommands:
   EnergyPlus schema versions.
 - ``idfkit migrate`` — forward-migrate an IDF model to a newer EnergyPlus
   version via the installed ``IDFVersionUpdater`` transition binaries.
+- ``idfkit tmy`` — search and download TMYx typical meteorological year
+  weather data from climate.onebuilding.org (EPW + DDY + STAT), optionally
+  via an interactive map browser.
 
 Usage examples::
 
@@ -14,6 +17,9 @@ Usage examples::
     idfkit check script.py --targets 24.2,25.1,25.2 --json
     idfkit migrate old.idf --to 25.2
     idfkit migrate old.idf --output new.idf --to 25.2 --json
+    idfkit tmy "chicago ohare"
+    idfkit tmy --wmo 725300 --download ./weather/
+    idfkit tmy --browse
 """
 
 from __future__ import annotations
@@ -29,6 +35,8 @@ from typing import TYPE_CHECKING
 from ..exceptions import EnergyPlusNotFoundError, MigrationError, UnsupportedVersionError
 from ..migration import MigrationProgress, MigrationReport, migrate
 from ..versions import ENERGYPLUS_VERSIONS, LATEST_VERSION, version_string
+from ..weather._cli import add_subparser as _add_tmy_subparser
+from ..weather._cli import run_tmy as _run_tmy
 from ._checker import check_compatibility, resolve_version
 from ._models import DIAGNOSTIC_CODES, CompatSeverity, Diagnostic
 from ._sarif import format_sarif
@@ -245,6 +253,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Suppress progress output (final report is still written unless --json is off).",
     )
 
+    _add_tmy_subparser(sub)
+
     return top
 
 
@@ -358,6 +368,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_check(args)
     elif args.command == "migrate":
         _run_migrate(args)
+    elif args.command == "tmy":
+        sys.exit(_run_tmy(args))
 
 
 def _run_check(args: argparse.Namespace) -> None:

--- a/src/idfkit/weather/_browser/__init__.py
+++ b/src/idfkit/weather/_browser/__init__.py
@@ -1,0 +1,11 @@
+"""Web UI for browsing and downloading TMYx weather stations.
+
+The browser is implemented as a stdlib-only ``http.server`` serving a
+single-page Leaflet map. Bundled assets live under ``assets/``.
+"""
+
+from __future__ import annotations
+
+from .server import launch_browser
+
+__all__ = ["launch_browser"]

--- a/src/idfkit/weather/_browser/assets/app.js
+++ b/src/idfkit/weather/_browser/assets/app.js
@@ -1,0 +1,488 @@
+/* idfkit tmy browser — client-side map + filter + download */
+
+(() => {
+  'use strict';
+
+  const $ = (id) => document.getElementById(id);
+  const MAX_LIST = 100;
+
+  let allStations = [];
+  let allGroups = [];
+  let filteredGroups = [];
+  let map = null;
+  let clusterGroup = null;
+  let canvasRenderer = null;
+  const markerByGroup = new Map();
+  let config = null;
+  let baseLayer = null;
+  const darkMedia = window.matchMedia('(prefers-color-scheme: dark)');
+
+  /* ── Utilities ─────────────────────────────────────────── */
+
+  const displayName = (s) => {
+    const name = (s.city || '').replace(/\./g, ' ').replace(/-/g, ' ').trim();
+    const parts = [];
+    if (name) parts.push(name);
+    if (s.state) parts.push(s.state);
+    if (s.country) parts.push(s.country);
+    return parts.join(', ');
+  };
+
+  const datasetVariant = (s) => {
+    const file = (s.url || '').split('/').pop() || '';
+    const stem = file.replace(/\.zip$/i, '');
+    const idx = stem.lastIndexOf('_');
+    return idx >= 0 ? stem.slice(idx + 1) : stem;
+  };
+
+  const filenameStem = (s) => {
+    const file = (s.url || '').split('/').pop() || '';
+    return file.replace(/\.zip$/i, '');
+  };
+
+  const haversineKm = (lat1, lon1, lat2, lon2) => {
+    const R = 6371;
+    const toRad = (d) => (d * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    return 2 * R * Math.asin(Math.sqrt(a));
+  };
+
+  const toast = (msg, variant = '') => {
+    const el = $('toast');
+    el.textContent = msg;
+    el.className = 'visible ' + variant;
+    clearTimeout(el._t);
+    el._t = setTimeout(() => {
+      el.className = '';
+    }, 3000);
+  };
+
+  /* ── Loading ───────────────────────────────────────────── */
+
+  async function loadStations() {
+    const resp = await fetch('/stations.json.gz');
+    if (!resp.ok) throw new Error(`stations fetch failed: ${resp.status}`);
+    const data = await resp.json();
+    return data.stations || [];
+  }
+
+  async function loadConfig() {
+    const resp = await fetch('/api/config');
+    return resp.ok ? resp.json() : {};
+  }
+
+  /* ── Grouping ──────────────────────────────────────────── */
+
+  /** Group stations by WMO (fallback: filename stem). A single group
+   *  represents one physical weather station with N dataset variants. */
+  function groupStations(stations) {
+    const groups = new Map();
+    for (const s of stations) {
+      const key = (s.wmo && s.wmo.trim()) || filenameStem(s);
+      let g = groups.get(key);
+      if (!g) {
+        g = {
+          key,
+          wmo: s.wmo,
+          country: s.country,
+          state: s.state,
+          city: s.city,
+          latitude: s.latitude,
+          longitude: s.longitude,
+          elevation: s.elevation,
+          timezone: s.timezone,
+          variants: [],
+        };
+        groups.set(key, g);
+      }
+      g.variants.push(s);
+    }
+
+    // Sort variants within each group so the default "TMYx" (no year range)
+    // shows first, then year-range variants newest-first.
+    for (const g of groups.values()) {
+      g.variants.sort((a, b) => {
+        const va = datasetVariant(a);
+        const vb = datasetVariant(b);
+        const ya = /(\d{4})-(\d{4})$/.exec(va);
+        const yb = /(\d{4})-(\d{4})$/.exec(vb);
+        if (!ya && yb) return -1;
+        if (ya && !yb) return 1;
+        if (ya && yb) return Number(yb[2]) - Number(ya[2]);
+        return va.localeCompare(vb);
+      });
+    }
+
+    return Array.from(groups.values());
+  }
+
+  /* ── Filtering ─────────────────────────────────────────── */
+
+  function applyFilters() {
+    const q = ($('search').value || '').trim().toLowerCase();
+    const country = ($('country').value || '').trim().toUpperCase();
+    const state = ($('state').value || '').trim().toUpperCase();
+    const variantQ = ($('variant').value || '').trim().toLowerCase();
+    const qTokens = q ? q.split(/\s+/).filter(Boolean) : [];
+
+    let out = [];
+    for (const g of allGroups) {
+      if (country && g.country.toUpperCase() !== country) continue;
+      if (state && g.state.toUpperCase() !== state) continue;
+      if (variantQ && !g.variants.some((v) => datasetVariant(v).toLowerCase().includes(variantQ))) {
+        continue;
+      }
+      if (qTokens.length) {
+        const hay = (
+          displayName(g) +
+          ' ' +
+          (g.wmo || '') +
+          ' ' +
+          g.variants.map(filenameStem).join(' ')
+        ).toLowerCase();
+        if (!qTokens.every((t) => hay.includes(t))) continue;
+      }
+      out.push(g);
+    }
+
+    // Spatial ordering when config seeded a map center
+    if (config && config.lat != null && config.lon != null) {
+      out = out
+        .map((g) => ({ g, d: haversineKm(config.lat, config.lon, g.latitude, g.longitude) }))
+        .filter((x) => config.max_km == null || x.d <= config.max_km)
+        .sort((a, b) => a.d - b.d)
+        .map((x) => x.g);
+    }
+
+    filteredGroups = out;
+    renderResults();
+    renderMarkers();
+  }
+
+  /* ── Rendering ─────────────────────────────────────────── */
+
+  function renderResults() {
+    const list = $('results');
+    const totalGroups = filteredGroups.length;
+    const totalVariants = filteredGroups.reduce((n, g) => n + g.variants.length, 0);
+    $('total').textContent = totalGroups.toLocaleString();
+    $('total-variants').textContent = totalVariants.toLocaleString();
+
+    list.innerHTML = '';
+    const shown = filteredGroups.slice(0, MAX_LIST);
+    const frag = document.createDocumentFragment();
+
+    for (const g of shown) {
+      const row = document.createElement('div');
+      row.className = 'result';
+
+      const name = document.createElement('div');
+      name.className = 'name';
+      name.textContent = displayName(g);
+      row.appendChild(name);
+
+      const meta = document.createElement('div');
+      meta.className = 'meta';
+
+      if (g.wmo) {
+        const wmo = document.createElement('span');
+        wmo.className = 'wmo';
+        wmo.textContent = 'WMO ' + g.wmo;
+        meta.appendChild(wmo);
+      }
+
+      const count = document.createElement('span');
+      count.className = 'count';
+      count.textContent = g.variants.length + (g.variants.length === 1 ? ' dataset' : ' datasets');
+      meta.appendChild(count);
+
+      if (config && config.lat != null && config.lon != null) {
+        const d = haversineKm(config.lat, config.lon, g.latitude, g.longitude);
+        const dist = document.createElement('span');
+        dist.className = 'dist';
+        dist.textContent = d.toFixed(0) + ' km';
+        meta.appendChild(dist);
+      }
+
+      row.appendChild(meta);
+      row.addEventListener('click', () => focusGroup(g));
+      frag.appendChild(row);
+    }
+
+    if (totalGroups > MAX_LIST) {
+      const more = document.createElement('div');
+      more.className = 'result muted small';
+      more.textContent = `+ ${totalGroups - MAX_LIST} more — refine filters to narrow`;
+      frag.appendChild(more);
+    }
+
+    if (totalGroups === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'result muted';
+      empty.textContent = 'No stations match.';
+      frag.appendChild(empty);
+    }
+
+    list.appendChild(frag);
+  }
+
+  function currentMarkerStyle() {
+    const cs = getComputedStyle(document.documentElement);
+    const accent = cs.getPropertyValue('--accent').trim() || '#3ea6ff';
+    return {
+      renderer: canvasRenderer,
+      radius: 5,
+      weight: 1,
+      color: '#ffffff',
+      fillColor: accent,
+      fillOpacity: 0.85,
+      opacity: 1,
+    };
+  }
+
+  function renderMarkers() {
+    if (!clusterGroup) return;
+    clusterGroup.clearLayers();
+    markerByGroup.clear();
+
+    // Canvas-rendered circle markers: one <canvas> paints all 17k dots,
+    // so Safari/Chrome only recomposite a single layer on zoom/pan.
+    const style = currentMarkerStyle();
+    const markers = [];
+    for (const g of filteredGroups) {
+      const m = L.circleMarker([g.latitude, g.longitude], style);
+      m._tmyGroup = g;
+      markers.push(m);
+      markerByGroup.set(g, m);
+    }
+    clusterGroup.addLayers(markers);
+  }
+
+  function retintMarkers() {
+    if (!clusterGroup || markerByGroup.size === 0) return;
+    const { fillColor } = currentMarkerStyle();
+    clusterGroup.eachLayer((layer) => {
+      if (typeof layer.setStyle === 'function') layer.setStyle({ fillColor });
+    });
+  }
+
+  /* ── Focus / detail ────────────────────────────────────── */
+
+  function focusGroup(g) {
+    map.setView([g.latitude, g.longitude], Math.max(map.getZoom(), 8));
+    const m = markerByGroup.get(g);
+    if (m && clusterGroup.hasLayer(m)) {
+      clusterGroup.zoomToShowLayer(m, () => openDetail(g));
+    } else {
+      openDetail(g);
+    }
+  }
+
+  function openDetail(g) {
+    $('detail-name').textContent = displayName(g);
+    $('detail-wmo').textContent = g.wmo || '—';
+    $('detail-country').textContent = g.country || '—';
+    $('detail-state').textContent = g.state || '—';
+    $('detail-coords').textContent = `${g.latitude.toFixed(4)}, ${g.longitude.toFixed(4)}`;
+    $('detail-elev').textContent = `${g.elevation} m`;
+    $('detail-tz').textContent = `GMT ${g.timezone >= 0 ? '+' : ''}${g.timezone}`;
+
+    const list = $('variant-list');
+    list.innerHTML = '';
+    for (const v of g.variants) {
+      list.appendChild(renderVariantRow(v));
+    }
+
+    const dlg = $('detail');
+    if (typeof dlg.showModal === 'function') dlg.showModal();
+    else dlg.setAttribute('open', '');
+  }
+
+  function renderVariantRow(v) {
+    const li = document.createElement('li');
+    li.className = 'variant-row';
+
+    const info = document.createElement('div');
+    info.className = 'variant-info';
+    const name = document.createElement('div');
+    name.className = 'variant-name';
+    name.textContent = datasetVariant(v);
+    info.appendChild(name);
+    const sub = document.createElement('div');
+    sub.className = 'variant-sub muted small';
+    sub.textContent = v.source || '';
+    info.appendChild(sub);
+    li.appendChild(info);
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'variant-download';
+    btn.textContent = 'Download .zip';
+    btn.addEventListener('click', () => triggerDownload(v, btn));
+    li.appendChild(btn);
+
+    return li;
+  }
+
+  async function triggerDownload(s, btn) {
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Fetching…';
+
+    const stem = filenameStem(s);
+    const url =
+      '/api/zip?wmo=' +
+      encodeURIComponent(s.wmo || '') +
+      '&filename=' +
+      encodeURIComponent(stem);
+
+    let objectUrl = null;
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) {
+        const msg = await resp.text();
+        throw new Error(msg || `download failed (${resp.status})`);
+      }
+      const blob = await resp.blob();
+      objectUrl = URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = objectUrl;
+      a.download = stem + '.zip';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+
+      btn.textContent = 'Saved ✓';
+      btn.disabled = false;
+      toast(`Saved ${stem}.zip`, 'good');
+      setTimeout(() => {
+        btn.textContent = original;
+      }, 2500);
+    } catch (err) {
+      btn.disabled = false;
+      btn.textContent = 'Retry';
+      toast(err.message || String(err), 'bad');
+    } finally {
+      if (objectUrl) setTimeout(() => URL.revokeObjectURL(objectUrl), 10000);
+    }
+  }
+
+  /* ── Initialisation ────────────────────────────────────── */
+
+  function tileLayerForScheme() {
+    const variant = darkMedia.matches ? 'dark_all' : 'light_all';
+    return L.tileLayer(
+      `https://{s}.basemaps.cartocdn.com/${variant}/{z}/{x}/{y}{r}.png`,
+      {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> ' +
+          '&copy; <a href="https://carto.com/attributions">CARTO</a>',
+        subdomains: 'abcd',
+        maxZoom: 19,
+      },
+    );
+  }
+
+  function applyColorScheme() {
+    if (!map) return;
+    if (baseLayer) map.removeLayer(baseLayer);
+    baseLayer = tileLayerForScheme().addTo(map);
+    retintMarkers();
+  }
+
+  function initMap() {
+    map = L.map('map', {
+      center: [30, 0],
+      zoom: 2,
+      worldCopyJump: true,
+      preferCanvas: true,
+    });
+    // Single canvas renderer shared by every circleMarker on the map:
+    // painting happens in one <canvas>, not 17k DOM nodes.
+    canvasRenderer = L.canvas({ padding: 0.5 });
+
+    applyColorScheme();
+    darkMedia.addEventListener('change', applyColorScheme);
+
+    clusterGroup = L.markerClusterGroup({
+      chunkedLoading: true,
+      chunkInterval: 120,
+      maxClusterRadius: 80,
+      disableClusteringAtZoom: 12,
+      spiderfyOnMaxZoom: false,
+      showCoverageOnHover: false,
+      zoomToBoundsOnClick: true,
+      animate: true,
+      animateAddingMarkers: false,
+    });
+
+    // One delegated click handler for all 17k markers.
+    clusterGroup.on('click', (e) => {
+      const group = e.layer && e.layer._tmyGroup;
+      if (group) openDetail(group);
+    });
+
+    map.addLayer(clusterGroup);
+  }
+
+  function seedFiltersFromConfig(cfg) {
+    if (!cfg) return;
+    if (cfg.query) $('search').value = cfg.query;
+    if (cfg.country) $('country').value = cfg.country;
+    if (cfg.state) $('state').value = cfg.state;
+    if (cfg.variant) $('variant').value = cfg.variant;
+  }
+
+  function wireInputs() {
+    const debounce = (fn, ms) => {
+      let t;
+      return (...args) => {
+        clearTimeout(t);
+        t = setTimeout(() => fn(...args), ms);
+      };
+    };
+    const handler = debounce(applyFilters, 150);
+    ['search', 'country', 'state', 'variant'].forEach((id) =>
+      $(id).addEventListener('input', handler),
+    );
+
+    $('detail-close').addEventListener('click', () => $('detail').close());
+    $('detail').addEventListener('click', (e) => {
+      if (e.target.id === 'detail') $('detail').close();
+    });
+  }
+
+  async function boot() {
+    initMap();
+    wireInputs();
+
+    try {
+      toast('Loading station index…');
+      const [stations, cfg] = await Promise.all([loadStations(), loadConfig()]);
+      allStations = stations;
+      allGroups = groupStations(stations);
+      config = cfg;
+      seedFiltersFromConfig(cfg);
+
+      if (cfg && cfg.lat != null && cfg.lon != null) {
+        map.setView([cfg.lat, cfg.lon], 6);
+      }
+
+      applyFilters();
+      toast(
+        `Loaded ${allGroups.length.toLocaleString()} stations (${allStations.length.toLocaleString()} datasets)`,
+        'good',
+      );
+    } catch (err) {
+      console.error(err);
+      toast('Failed to load stations: ' + (err.message || err), 'bad');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', boot);
+})();

--- a/src/idfkit/weather/_browser/assets/index.html
+++ b/src/idfkit/weather/_browser/assets/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>idfkit tmy — TMYx weather browser</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"
+    />
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <aside id="sidebar">
+      <header>
+        <h1>idfkit <span class="muted">tmy</span></h1>
+        <p class="muted small">TMYx typical-year weather from climate.onebuilding.org</p>
+      </header>
+
+      <section class="filters">
+        <input
+          id="search"
+          type="search"
+          placeholder="City, WMO, or EPW filename…"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <div class="row">
+          <input id="country" type="text" placeholder="Country (USA)" maxlength="3" />
+          <input id="state" type="text" placeholder="State (IL)" maxlength="3" />
+        </div>
+        <input id="variant" type="text" placeholder="Variant (e.g. 2009-2023)" />
+        <div class="stats muted small">
+          <span id="total">0</span> stations ·
+          <span id="total-variants">0</span> datasets
+        </div>
+      </section>
+
+      <section id="results" class="results"></section>
+
+      <footer>
+        <span class="muted small">
+          Click a marker to view and download. Files go to the platform cache.
+        </span>
+      </footer>
+    </aside>
+
+    <main>
+      <div id="map"></div>
+    </main>
+
+    <dialog id="detail">
+      <header>
+        <h2 id="detail-name"></h2>
+        <button id="detail-close" aria-label="Close">×</button>
+      </header>
+      <dl>
+        <dt>WMO</dt><dd id="detail-wmo"></dd>
+        <dt>Country</dt><dd id="detail-country"></dd>
+        <dt>State</dt><dd id="detail-state"></dd>
+        <dt>Coords</dt><dd id="detail-coords"></dd>
+        <dt>Elevation</dt><dd id="detail-elev"></dd>
+        <dt>Timezone</dt><dd id="detail-tz"></dd>
+      </dl>
+      <section class="variants">
+        <h3>Available datasets</h3>
+        <ul id="variant-list"></ul>
+      </section>
+    </dialog>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
+    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/src/idfkit/weather/_browser/assets/style.css
+++ b/src/idfkit/weather/_browser/assets/style.css
@@ -1,0 +1,228 @@
+/* Light theme is the default; dark theme is applied via prefers-color-scheme. */
+:root {
+  --bg: #ffffff;
+  --panel: #f6f8fa;
+  --panel-2: #eef1f4;
+  --border: #d0d7de;
+  --text: #1f2328;
+  --muted: #656d76;
+  --accent: #0969da;
+  --accent-2: #218bff;
+  --on-accent: #ffffff;
+  --good: #1a7f37;
+  --warn: #9a6700;
+  --bad: #cf222e;
+  --map-bg: #e4e9ef;
+  --cluster-halo: rgba(9, 105, 218, 0.15);
+  --cluster-fill: rgba(9, 105, 218, 0.55);
+  --toast-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  --dialog-backdrop: rgba(31, 35, 40, 0.4);
+  --mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --panel: #161b22;
+    --panel-2: #1c232b;
+    --border: #30363d;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --accent-2: #79c0ff;
+    --on-accent: #0d1117;
+    --good: #3fb950;
+    --warn: #d29922;
+    --bad: #f85149;
+    --map-bg: #0a0e13;
+    --cluster-halo: rgba(88, 166, 255, 0.3);
+    --cluster-fill: rgba(88, 166, 255, 0.65);
+    --toast-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+    --dialog-backdrop: rgba(0, 0, 0, 0.6);
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0; height: 100%;
+  background: var(--bg); color: var(--text);
+  font-family: var(--sans); font-size: 14px; line-height: 1.5;
+  overflow: hidden;
+}
+
+body {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  grid-template-rows: 100%;
+}
+
+.muted { color: var(--muted); }
+.small { font-size: 12px; }
+
+/* ── Sidebar ──────────────────────────────────────────────── */
+
+#sidebar {
+  background: var(--panel);
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+
+#sidebar header {
+  padding: 16px 18px 12px; border-bottom: 1px solid var(--border);
+}
+#sidebar h1 {
+  margin: 0; font-size: 18px; font-weight: 600; letter-spacing: -0.01em;
+}
+#sidebar h1 span { font-weight: 400; }
+#sidebar header p { margin: 4px 0 0; }
+
+.filters {
+  padding: 12px 14px; border-bottom: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+}
+
+.filters input[type="text"],
+.filters input[type="search"] {
+  background: var(--bg); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 8px 10px; font: inherit; width: 100%;
+  outline: none; transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.filters input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+.filters .row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+.stats { padding-top: 4px; }
+.stats #total { color: var(--text); font-variant-numeric: tabular-nums; font-weight: 600; }
+
+/* ── Results list ─────────────────────────────────────────── */
+
+.results { flex: 1; overflow-y: auto; padding: 4px 0; }
+.result {
+  padding: 10px 14px; border-bottom: 1px solid var(--border);
+  cursor: pointer; transition: background 80ms ease;
+}
+.result:hover { background: var(--panel-2); }
+.result.active { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.result .name { font-weight: 600; color: var(--text); }
+.result .meta {
+  margin-top: 2px; color: var(--muted); font-size: 12px;
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+.result .meta .wmo { color: var(--accent-2); font-family: var(--mono); }
+.result .meta .count { color: var(--muted); font-family: var(--mono); }
+.result .meta .dist { color: var(--good); font-variant-numeric: tabular-nums; }
+
+#sidebar footer {
+  padding: 10px 14px; border-top: 1px solid var(--border); background: var(--panel-2);
+}
+
+/* ── Map ─────────────────────────────────────────────────── */
+
+main { position: relative; }
+#map { position: absolute; inset: 0; background: var(--map-bg); }
+
+.leaflet-container { background: var(--map-bg); }
+
+/* Theme-aware marker-cluster tints (leaflet.markercluster overrides) */
+.marker-cluster-small,
+.marker-cluster-medium,
+.marker-cluster-large { background-color: var(--cluster-halo); }
+.marker-cluster-small div,
+.marker-cluster-medium div,
+.marker-cluster-large div { background-color: var(--cluster-fill); color: white; }
+
+/* ── Popups ─────────────────────────────────────────────── */
+
+.leaflet-popup-content-wrapper {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--border); border-radius: 8px;
+}
+.leaflet-popup-tip { background: var(--panel); }
+.leaflet-popup-content { margin: 10px 12px; min-width: 220px; }
+.leaflet-popup-content .pop-name { font-weight: 600; font-size: 13px; }
+.leaflet-popup-content .pop-meta { color: var(--muted); font-size: 12px; margin-top: 2px; }
+.leaflet-popup-content button {
+  margin-top: 8px;
+  background: var(--accent); color: var(--on-accent);
+  border: 0; border-radius: 5px; padding: 6px 10px;
+  font: inherit; font-weight: 600; cursor: pointer;
+}
+.leaflet-popup-content button:hover { background: var(--accent-2); }
+
+/* ── Detail dialog ──────────────────────────────────────── */
+
+dialog#detail {
+  background: var(--panel); color: var(--text);
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 0; max-width: 440px; width: 92%;
+}
+dialog#detail::backdrop { background: var(--dialog-backdrop); }
+dialog#detail header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px; border-bottom: 1px solid var(--border);
+}
+dialog#detail h2 { margin: 0; font-size: 15px; font-weight: 600; }
+dialog#detail button#detail-close {
+  background: transparent; color: var(--muted); border: 0; cursor: pointer;
+  font-size: 22px; line-height: 1;
+}
+dialog#detail dl {
+  margin: 0; padding: 14px 18px;
+  display: grid; grid-template-columns: 90px 1fr; gap: 6px 12px;
+  font-size: 13px;
+}
+dialog#detail dt { color: var(--muted); }
+dialog#detail dd { margin: 0; font-family: var(--mono); }
+
+.variants {
+  border-top: 1px solid var(--border);
+  padding: 14px 18px 16px;
+}
+.variants h3 {
+  margin: 0 0 10px; font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--muted);
+}
+.variants ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.variant-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.variant-info { min-width: 0; }
+.variant-name {
+  font-family: var(--mono); font-size: 12px; color: var(--text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.variant-sub { margin-top: 2px; font-family: var(--mono); }
+.variant-download {
+  flex-shrink: 0;
+  background: var(--accent); color: var(--on-accent); border: 0;
+  border-radius: 5px; padding: 6px 10px;
+  font: inherit; font-weight: 600; font-size: 12px; cursor: pointer;
+  min-width: 108px; text-align: center;
+}
+.variant-download:hover { background: var(--accent-2); }
+.variant-download[disabled] { opacity: 0.6; cursor: progress; }
+
+/* ── Toast ──────────────────────────────────────────────── */
+
+#toast {
+  position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+  background: var(--panel); border: 1px solid var(--border);
+  color: var(--text); padding: 10px 16px; border-radius: 8px;
+  font-size: 13px; pointer-events: none;
+  opacity: 0; transition: opacity 200ms ease;
+  box-shadow: var(--toast-shadow);
+}
+#toast.visible { opacity: 1; }
+#toast.good { border-color: var(--good); }
+#toast.bad { border-color: var(--bad); }

--- a/src/idfkit/weather/_browser/server.py
+++ b/src/idfkit/weather/_browser/server.py
@@ -1,0 +1,275 @@
+"""Stdlib HTTP server for the ``idfkit tmy --browse`` interactive map.
+
+Endpoints:
+
+* ``GET  /``                   index.html
+* ``GET  /app.js``             client application
+* ``GET  /style.css``          styles
+* ``GET  /stations.json.gz``   bundled station index (content-encoded gzip)
+* ``GET  /api/config``         initial filter state from CLI flags
+* ``GET  /api/zip``            stream a station's ZIP to the user's browser
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+import webbrowser
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
+
+from ..index import (
+    _BUNDLED_INDEX,  # pyright: ignore[reportPrivateUsage]
+    _CACHED_INDEX,  # pyright: ignore[reportPrivateUsage]
+    default_cache_dir,
+)
+
+if TYPE_CHECKING:
+    from .._cli import TmyBrowserConfig, TmyFilters  # pyright: ignore[reportPrivateUsage]
+    from ..index import StationIndex
+
+logger = logging.getLogger(__name__)
+
+_ASSETS_DIR = Path(__file__).parent / "assets"
+
+_MIME_TYPES: dict[str, str] = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".ico": "image/x-icon",
+}
+
+
+# ---------------------------------------------------------------------------
+# Server-side state (shared across handlers)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserState:
+    """Immutable server state; shared via a class attribute on the handler."""
+
+    index: StationIndex
+    filters: TmyFilters
+    cache_dir: Path | None
+    quiet: bool
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def _send_plain(handler: BaseHTTPRequestHandler, status: HTTPStatus, message: str) -> None:
+    body = message.encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "text/plain; charset=utf-8")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _send_json(
+    handler: BaseHTTPRequestHandler,
+    status: HTTPStatus,
+    payload: dict[str, object],
+) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _serve_asset(handler: BaseHTTPRequestHandler, name: str) -> None:
+    asset_path = _ASSETS_DIR / name
+    if not asset_path.is_file():
+        _send_plain(handler, HTTPStatus.NOT_FOUND, f"asset not found: {name}")
+        return
+    body = asset_path.read_bytes()
+    ctype = _MIME_TYPES.get(asset_path.suffix.lower(), "application/octet-stream")
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("Content-Type", ctype)
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Cache-Control", "no-cache")
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _serve_stations_gz(handler: BaseHTTPRequestHandler, state: BrowserState) -> None:
+    cache_source = (state.cache_dir or default_cache_dir()) / _CACHED_INDEX
+    source = cache_source if cache_source.is_file() else _BUNDLED_INDEX
+    if not source.is_file():
+        _send_plain(handler, HTTPStatus.NOT_FOUND, "station index missing; run --refresh")
+        return
+    body = source.read_bytes()
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Content-Encoding", "gzip")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Cache-Control", "no-cache")
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _serve_config(handler: BaseHTTPRequestHandler, state: BrowserState) -> None:
+    f = state.filters
+    payload: dict[str, object] = {
+        "query": f.query,
+        "wmo": f.wmo,
+        "filename": f.filename,
+        "near": f.near,
+        "lat": f.lat,
+        "lon": f.lon,
+        "max_km": f.max_km,
+        "country": f.country,
+        "state": f.state,
+        "variant": f.variant,
+        "cache_dir": str(state.cache_dir) if state.cache_dir else str(default_cache_dir()),
+    }
+    _send_json(handler, HTTPStatus.OK, payload)
+
+
+def _serve_zip(handler: BaseHTTPRequestHandler, state: BrowserState) -> None:
+    """Stream a station's ZIP to the client as a browser file download.
+
+    The ZIP is fetched (or served from cache) via ``WeatherDownloader``
+    server-side, then written back with ``Content-Disposition: attachment``
+    so the browser saves it to the user's Downloads folder.
+    """
+    params = parse_qs(urlparse(handler.path).query)
+    wmo = (params.get("wmo", [""])[0] or "").strip()
+    filename = (params.get("filename", [""])[0] or "").strip()
+    if not wmo and not filename:
+        _send_plain(handler, HTTPStatus.BAD_REQUEST, "wmo or filename query parameter required")
+        return
+
+    stations = state.index.get_by_filename(filename) if filename else state.index.get_by_wmo(wmo)
+    if not stations:
+        _send_plain(handler, HTTPStatus.NOT_FOUND, "no station found")
+        return
+    station = stations[0]
+
+    from ..download import WeatherDownloader
+
+    downloader = WeatherDownloader(cache_dir=state.cache_dir)
+    try:
+        files = downloader.download(station)
+    except RuntimeError as exc:
+        _send_plain(handler, HTTPStatus.BAD_GATEWAY, f"fetch failed: {exc}")
+        return
+
+    zip_path = files.zip_path
+    if not zip_path.is_file():  # pragma: no cover - defensive; download() creates the file
+        _send_plain(handler, HTTPStatus.INTERNAL_SERVER_ERROR, "zip missing after fetch")
+        return
+    body = zip_path.read_bytes()
+
+    handler.send_response(HTTPStatus.OK)
+    handler.send_header("Content-Type", "application/zip")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.send_header("Content-Disposition", f'attachment; filename="{zip_path.name}"')
+    handler.send_header("Cache-Control", "no-cache")
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+_GET_ROUTES: dict[str, str] = {
+    "/": "index.html",
+    "/app.js": "app.js",
+    "/style.css": "style.css",
+}
+
+
+def _make_handler(state: BrowserState) -> type[BaseHTTPRequestHandler]:
+    """Build a handler class closed over shared server state."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            if not state.quiet:
+                sys.stderr.write(f"[tmy browser] {format % args}\n")
+
+        def do_GET(self) -> None:
+            path = urlparse(self.path).path
+            asset = _GET_ROUTES.get(path)
+            if asset is not None:
+                _serve_asset(self, asset)
+                return
+            if path == "/stations.json.gz":
+                _serve_stations_gz(self, state)
+                return
+            if path == "/api/config":
+                _serve_config(self, state)
+                return
+            if path == "/api/zip":
+                _serve_zip(self, state)
+                return
+            _send_plain(self, HTTPStatus.NOT_FOUND, "not found")
+
+    return Handler
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def launch_browser(
+    *,
+    index: StationIndex,
+    filters: TmyFilters,
+    browser: TmyBrowserConfig,
+    cache_dir: Path | None,
+    quiet: bool,
+) -> int:
+    """Start the HTTP server, optionally open a browser, and block until Ctrl+C.
+
+    Returns the process exit code suitable for ``sys.exit``.
+    """
+    state = BrowserState(index=index, filters=filters, cache_dir=cache_dir, quiet=quiet)
+    handler_cls = _make_handler(state)
+
+    try:
+        server = ThreadingHTTPServer((browser.host, browser.port), handler_cls)
+    except OSError as exc:
+        print(f"error: cannot bind to {browser.host}:{browser.port}: {exc}", file=sys.stderr)
+        return 2
+
+    host, port = server.server_address[0], server.server_address[1]
+    # Prefer an addressable URL when the server is bound to a wildcard.
+    display_host = "localhost" if host in {"0.0.0.0", ""} else host  # noqa: S104 - just for display
+    url = f"http://{display_host}:{port}/"
+
+    if not quiet:
+        print(f"[tmy browser] Serving {len(index)} stations at {url}", file=sys.stderr)
+        print("[tmy browser] Press Ctrl+C to stop.", file=sys.stderr)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    if browser.open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            if not quiet:
+                print(f"[tmy browser] Open {url} manually.", file=sys.stderr)
+
+    try:
+        thread.join()
+    except KeyboardInterrupt:
+        if not quiet:
+            print("\n[tmy browser] Shutting down...", file=sys.stderr)
+        server.shutdown()
+        server.server_close()
+        return 0
+    return 0

--- a/src/idfkit/weather/_cli.py
+++ b/src/idfkit/weather/_cli.py
@@ -1,0 +1,866 @@
+"""CLI subcommand for TMYx weather data from climate.onebuilding.org.
+
+Registered under ``idfkit tmy``. Provides search, download, and an
+interactive map browser over the bundled station index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import enum
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError, URLError
+
+from .geocode import GeocodingError, geocode
+from .index import StationIndex, default_cache_dir
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .station import WeatherStation
+
+
+# ---------------------------------------------------------------------------
+# Exit codes (documented contract)
+# ---------------------------------------------------------------------------
+
+EXIT_OK = 0
+EXIT_NO_MATCHES = 1
+EXIT_USAGE = 2
+EXIT_NETWORK = 3
+
+# Sentinel used for ``--download`` without an explicit DIR argument.
+_DOWNLOAD_CACHE_SENTINEL = "__cache__"
+
+
+# ---------------------------------------------------------------------------
+# Typed configuration
+# ---------------------------------------------------------------------------
+
+
+class TmyAction(enum.Enum):
+    """The action to take after filters are applied."""
+
+    LIST = "list"
+    DOWNLOAD = "download"
+    BROWSE = "browse"
+    REFRESH = "refresh"
+
+
+@dataclass(frozen=True, slots=True)
+class TmyFilters:
+    """Station filter criteria assembled from CLI arguments."""
+
+    query: str | None = None
+    wmo: str | None = None
+    filename: str | None = None
+    near: str | None = None
+    lat: float | None = None
+    lon: float | None = None
+    max_km: float | None = None
+    country: str | None = None
+    state: str | None = None
+    variant: str | None = None
+
+    @property
+    def has_spatial(self) -> bool:
+        return self.near is not None or (self.lat is not None and self.lon is not None)
+
+    @property
+    def has_any(self) -> bool:
+        return any(
+            v is not None
+            for v in (
+                self.query,
+                self.wmo,
+                self.filename,
+                self.near,
+                self.lat,
+                self.country,
+                self.state,
+                self.variant,
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TmyOutputConfig:
+    """Output and UX settings."""
+
+    first: bool = False
+    limit: int = 10
+    json_output: bool = False
+    quiet: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TmyDownloadConfig:
+    """Download target; ``None`` means no download (list mode)."""
+
+    dir: Path | None = None
+    use_cache: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TmyBrowserConfig:
+    """Settings for the web browser UI."""
+
+    host: str = "127.0.0.1"
+    port: int = 0
+    open_browser: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class TmyMatch:
+    """A resolved station with optional ranking metadata.
+
+    ``score`` is populated by text search; ``distance_km`` by spatial
+    search. Both may be ``None`` for exact/metadata lookups.
+    """
+
+    station: WeatherStation
+    score: float | None = None
+    distance_km: float | None = None
+    match_field: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class TmyRunConfig:
+    """Fully resolved configuration for a single ``idfkit tmy`` invocation."""
+
+    action: TmyAction
+    filters: TmyFilters
+    output: TmyOutputConfig
+    download: TmyDownloadConfig
+    browser: TmyBrowserConfig
+    cache_dir: Path | None = None
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Argparse registration
+# ---------------------------------------------------------------------------
+
+_EPILOG = """\
+examples:
+  idfkit tmy "chicago ohare"
+  idfkit tmy --near "350 Fifth Ave, NYC" --max-km 25
+  idfkit tmy --wmo 725300 --variant 2009-2023 --download ./weather/
+  idfkit tmy "london" --first --download
+  idfkit tmy --browse
+  idfkit tmy --refresh
+
+behavior:
+  - TTY + multiple matches + --download  interactive picker
+  - non-TTY + multiple matches + --download  error; use --first or narrow filters
+  - progress  stderr   results  stdout
+  - exit 0 ok / 1 no matches / 2 usage / 3 network
+
+Data source: TMYx typical meteorological year datasets from
+climate.onebuilding.org. Each ZIP ships EPW (8760 hourly values), DDY
+(ASHRAE design days), and STAT (climate summary). These are synthetic
+typical years, not historical measurements or live observations.
+"""
+
+
+def add_subparser(
+    sub: argparse._SubParsersAction[argparse.ArgumentParser],  # pyright: ignore[reportPrivateUsage]
+) -> None:
+    """Register the ``tmy`` subcommand on the top-level CLI parser."""
+    p = sub.add_parser(
+        "tmy",
+        help="Search and download TMYx typical meteorological year data",
+        description=(
+            "Search and download TMYx typical meteorological year data from "
+            "climate.onebuilding.org. Each station ships EPW (8760h), DDY "
+            "(ASHRAE design days), and STAT (climate summary). These are "
+            "synthetic typical years, not historical measurements."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_EPILOG,
+    )
+
+    p.add_argument("query", nargs="?", metavar="QUERY", help="Free-text search query")
+
+    p.add_argument("--wmo", metavar="WMO", help="Exact WMO station number (e.g. 725300)")
+    p.add_argument("--filename", metavar="NAME", help="Exact EPW filename or stem")
+
+    p.add_argument("--near", metavar="ADDRESS", help="Geocode address, then find nearest stations")
+    p.add_argument("--lat", type=float, metavar="LAT", help="Latitude (decimal degrees, N positive)")
+    p.add_argument("--lon", type=float, metavar="LON", help="Longitude (decimal degrees, E positive)")
+    p.add_argument("--max-km", dest="max_km", type=float, metavar="KM", help="Maximum distance in km")
+
+    p.add_argument("--country", metavar="CC", help="ISO country code (e.g. USA, FRA, GBR)")
+    p.add_argument("--state", metavar="ST", help="State/province code")
+    p.add_argument(
+        "--variant",
+        metavar="STR",
+        help='Substring match on dataset variant (e.g. "TMYx", "TMYx.2009-2023", "2009-2023")',
+    )
+
+    actions = p.add_mutually_exclusive_group()
+    actions.add_argument(
+        "-d",
+        "--download",
+        dest="download",
+        nargs="?",
+        const=_DOWNLOAD_CACHE_SENTINEL,
+        default=None,
+        metavar="DIR",
+        help="Download the match; DIR defaults to the platform cache",
+    )
+    actions.add_argument("--browse", action="store_true", help="Launch the interactive web UI")
+    actions.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Rebuild the station index from upstream (requires [weather] extra)",
+    )
+
+    p.add_argument("--first", action="store_true", help="Non-interactive: pick top-scored match")
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Maximum results when listing (default: 10)",
+    )
+    p.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Machine-readable JSON output (auto-enabled when piped if --first)",
+    )
+    p.add_argument("-q", "--quiet", action="store_true", help="Suppress progress messages on stderr")
+
+    p.add_argument("--host", default="127.0.0.1", help="Browser bind host (default: 127.0.0.1)")
+    p.add_argument("--port", type=int, default=0, metavar="N", help="Browser port (default: random free)")
+    p.add_argument("--no-open", dest="no_open", action="store_true", help="Do not auto-open the web browser")
+
+    p.add_argument(
+        "--cache-dir",
+        dest="cache_dir",
+        default=None,
+        metavar="DIR",
+        help="Override the station cache directory",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Namespace → typed config
+# ---------------------------------------------------------------------------
+
+
+def _resolve_action(ns: argparse.Namespace) -> TmyAction:
+    if bool(getattr(ns, "refresh", False)):
+        return TmyAction.REFRESH
+    if bool(getattr(ns, "browse", False)):
+        return TmyAction.BROWSE
+    if getattr(ns, "download", None) is not None:
+        return TmyAction.DOWNLOAD
+    return TmyAction.LIST
+
+
+def _namespace_to_config(ns: argparse.Namespace) -> TmyRunConfig:
+    """Translate an argparse Namespace into a validated :class:`TmyRunConfig`.
+
+    Collected errors are attached to ``_errors`` on the returned config so
+    the caller can print them and exit cleanly.
+    """
+    errors: list[str] = []
+
+    filters = TmyFilters(
+        query=getattr(ns, "query", None),
+        wmo=getattr(ns, "wmo", None),
+        filename=getattr(ns, "filename", None),
+        near=getattr(ns, "near", None),
+        lat=getattr(ns, "lat", None),
+        lon=getattr(ns, "lon", None),
+        max_km=getattr(ns, "max_km", None),
+        country=getattr(ns, "country", None),
+        state=getattr(ns, "state", None),
+        variant=getattr(ns, "variant", None),
+    )
+
+    # Cross-flag validation
+    if filters.near is not None and (filters.lat is not None or filters.lon is not None):
+        errors.append("--near cannot be combined with --lat/--lon")
+    if (filters.lat is None) != (filters.lon is None):
+        errors.append("--lat and --lon must be specified together")
+    if filters.max_km is not None and not filters.has_spatial:
+        errors.append("--max-km requires --near or --lat/--lon")
+
+    action = _resolve_action(ns)
+
+    download_raw = getattr(ns, "download", None)
+    if download_raw == _DOWNLOAD_CACHE_SENTINEL:
+        download = TmyDownloadConfig(dir=None, use_cache=True)
+    elif download_raw is not None:
+        download = TmyDownloadConfig(dir=Path(download_raw), use_cache=False)
+    else:
+        download = TmyDownloadConfig()
+
+    output = TmyOutputConfig(
+        first=bool(getattr(ns, "first", False)),
+        limit=int(getattr(ns, "limit", 10)),
+        json_output=bool(getattr(ns, "json_output", False)),
+        quiet=bool(getattr(ns, "quiet", False)),
+    )
+
+    browser = TmyBrowserConfig(
+        host=str(getattr(ns, "host", "127.0.0.1")),
+        port=int(getattr(ns, "port", 0)),
+        open_browser=not bool(getattr(ns, "no_open", False)),
+    )
+
+    cache_dir_raw = getattr(ns, "cache_dir", None)
+    cache_dir = Path(cache_dir_raw) if cache_dir_raw else None
+
+    return TmyRunConfig(
+        action=action,
+        filters=filters,
+        output=output,
+        download=download,
+        browser=browser,
+        cache_dir=cache_dir,
+        errors=tuple(errors),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TTY / output helpers
+# ---------------------------------------------------------------------------
+
+
+def _stdout_is_tty() -> bool:
+    return sys.stdout.isatty()
+
+
+def _stderr_is_tty() -> bool:
+    return sys.stderr.isatty()
+
+
+def _info(msg: str, *, quiet: bool = False) -> None:
+    """Emit a progress/status line on stderr unless quiet."""
+    if not quiet:
+        print(msg, file=sys.stderr)
+
+
+def _error(msg: str) -> None:
+    """Emit an error line on stderr."""
+    print(f"error: {msg}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Filter resolution
+# ---------------------------------------------------------------------------
+
+
+def _variant_matches(station: WeatherStation, pattern: str) -> bool:
+    return pattern.lower() in station.dataset_variant.lower()
+
+
+def _post_filter(matches: Sequence[TmyMatch], filters: TmyFilters) -> list[TmyMatch]:
+    """Apply country/state/variant filters to already-resolved matches."""
+    result: list[TmyMatch] = []
+    for m in matches:
+        s = m.station
+        if filters.country and s.country.upper() != filters.country.upper():
+            continue
+        if filters.state and s.state.upper() != filters.state.upper():
+            continue
+        if filters.variant and not _variant_matches(s, filters.variant):
+            continue
+        result.append(m)
+    return result
+
+
+def _resolve_coords(filters: TmyFilters, *, quiet: bool) -> tuple[float, float] | None:
+    """Resolve the spatial anchor from ``--near`` or ``--lat/--lon``.
+
+    Returns ``None`` when no spatial filter is active. Raises
+    :class:`GeocodingError` on geocoding failure.
+    """
+    if filters.lat is not None and filters.lon is not None:
+        return filters.lat, filters.lon
+    if filters.near is not None:
+        _info(f"Geocoding '{filters.near}' via Nominatim...", quiet=quiet)
+        return geocode(filters.near)
+    return None
+
+
+def _resolve_matches(
+    index: StationIndex,
+    filters: TmyFilters,
+    *,
+    limit: int,
+    quiet: bool,
+) -> list[TmyMatch]:
+    """Apply filters to the index in priority order and return matches."""
+    # 1. Exact WMO
+    if filters.wmo is not None:
+        stations = index.get_by_wmo(filters.wmo)
+        matches = [TmyMatch(station=s, match_field="wmo") for s in stations]
+        return _post_filter(matches, filters)
+
+    # 2. Exact filename
+    if filters.filename is not None:
+        stations = index.get_by_filename(filters.filename)
+        matches = [TmyMatch(station=s, match_field="filename") for s in stations]
+        return _post_filter(matches, filters)
+
+    # 3. Spatial (optionally with query as text sub-filter)
+    if filters.has_spatial:
+        coords = _resolve_coords(filters, quiet=quiet)
+        if coords is None:  # pragma: no cover - guarded by has_spatial
+            return []
+        lat, lon = coords
+        # Pull a generous window so post-filters can narrow it.
+        spatial_limit = max(limit * 10, 50)
+        spatial = index.nearest(
+            lat,
+            lon,
+            limit=spatial_limit,
+            max_distance_km=filters.max_km,
+            country=filters.country,
+        )
+        matches = [TmyMatch(station=r.station, distance_km=r.distance_km) for r in spatial]
+        if filters.query:
+            q = filters.query.lower()
+            matches = [m for m in matches if q in m.station.display_name.lower()]
+        return _post_filter(matches, filters)
+
+    # 4. Text search
+    if filters.query:
+        search_limit = max(limit * 4, 40)
+        search = index.search(filters.query, limit=search_limit, country=filters.country)
+        matches = [TmyMatch(station=r.station, score=r.score, match_field=r.match_field) for r in search]
+        return _post_filter(matches, filters)
+
+    # 5. Metadata-only
+    if filters.country or filters.state or filters.variant:
+        matches = [TmyMatch(station=s) for s in index.stations]
+        return _post_filter(matches, filters)
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def _match_to_dict(m: TmyMatch) -> dict[str, object]:
+    return {
+        "station": m.station.to_dict(),
+        "display_name": m.station.display_name,
+        "dataset_variant": m.station.dataset_variant,
+        "filename_stem": m.station.filename_stem,
+        "score": m.score,
+        "distance_km": m.distance_km,
+        "match_field": m.match_field or None,
+    }
+
+
+def _format_json(matches: Sequence[TmyMatch]) -> str:
+    return json.dumps([_match_to_dict(m) for m in matches], indent=2)
+
+
+def _format_tsv(matches: Sequence[TmyMatch]) -> str:
+    """Tab-delimited output for non-TTY piping without ``--json``."""
+    lines: list[str] = ["country\tstate\tcity\twmo\tvariant\tlat\tlon\tscore\tdistance_km\turl"]
+    for m in matches:
+        s = m.station
+        score = f"{m.score:.2f}" if m.score is not None else ""
+        dist = f"{m.distance_km:.1f}" if m.distance_km is not None else ""
+        lines.append(
+            "\t".join([
+                s.country,
+                s.state,
+                s.city,
+                s.wmo,
+                s.dataset_variant,
+                f"{s.latitude:.4f}",
+                f"{s.longitude:.4f}",
+                score,
+                dist,
+                s.url,
+            ])
+        )
+    return "\n".join(lines)
+
+
+# Minimal ANSI styling — only applied when stdout is a TTY.
+_ANSI_RESET = "\x1b[0m"
+_ANSI_BOLD = "\x1b[1m"
+_ANSI_DIM = "\x1b[2m"
+_ANSI_CYAN = "\x1b[36m"
+_ANSI_GREEN = "\x1b[32m"
+
+
+def _style(text: str, *codes: str, enabled: bool) -> str:
+    if not enabled or not codes:
+        return text
+    return f"{''.join(codes)}{text}{_ANSI_RESET}"
+
+
+def _format_table(matches: Sequence[TmyMatch], *, color: bool) -> str:
+    if not matches:
+        return "No stations match the given filters."
+
+    # Column widths
+    name_w = max(len(m.station.display_name) for m in matches)
+    name_w = min(max(name_w, 20), 48)
+    variant_w = max(len(m.station.dataset_variant) for m in matches)
+    variant_w = min(max(variant_w, 8), 20)
+
+    has_dist = any(m.distance_km is not None for m in matches)
+
+    lines: list[str] = []
+    for i, m in enumerate(matches):
+        s = m.station
+        marker = "*" if i == 0 else " "
+        name = s.display_name
+        if len(name) > name_w:
+            name = name[: name_w - 1] + "…"
+        variant = s.dataset_variant
+        if len(variant) > variant_w:
+            variant = variant[: variant_w - 1] + "…"
+
+        parts: list[str] = []
+        parts.append(_style(marker, _ANSI_GREEN, _ANSI_BOLD, enabled=color) if i == 0 else marker)
+        parts.append(_style(f"{name:<{name_w}}", _ANSI_BOLD, enabled=color))
+        parts.append(_style(f"WMO {s.wmo:<7}", _ANSI_CYAN, enabled=color))
+        parts.append(f"{variant:<{variant_w}}")
+        if has_dist:
+            dist_str = f"{m.distance_km:6.1f} km" if m.distance_km is not None else " " * 9
+            parts.append(dist_str)
+        lines.append(" ".join(parts))
+
+    return "\n".join(lines)
+
+
+def _format_header(filters: TmyFilters, matches: Sequence[TmyMatch], *, color: bool) -> str:
+    bits: list[str] = []
+    if filters.query:
+        bits.append(f'query="{filters.query}"')
+    if filters.wmo:
+        bits.append(f"wmo={filters.wmo}")
+    if filters.filename:
+        bits.append(f"filename={filters.filename}")
+    if filters.near:
+        bits.append(f'near="{filters.near}"')
+    elif filters.lat is not None and filters.lon is not None:
+        bits.append(f"coords={filters.lat:.4f},{filters.lon:.4f}")
+    if filters.max_km is not None:
+        bits.append(f"max_km={filters.max_km}")
+    if filters.country:
+        bits.append(f"country={filters.country}")
+    if filters.state:
+        bits.append(f"state={filters.state}")
+    if filters.variant:
+        bits.append(f"variant={filters.variant}")
+
+    descriptor = ", ".join(bits) if bits else "all stations"
+    summary = f"Found {len(matches)} match" + ("" if len(matches) == 1 else "es")
+    return _style(f"{summary} — {descriptor}", _ANSI_DIM, enabled=color)
+
+
+def _next_action_hint(matches: Sequence[TmyMatch], *, color: bool) -> str:
+    if not matches:
+        return ""
+    top = matches[0].station
+    cmd = f"idfkit tmy --wmo {top.wmo} --variant {top.dataset_variant} --download"
+    return _style(f"\n→ {cmd}   to fetch the top match", _ANSI_DIM, enabled=color)
+
+
+# ---------------------------------------------------------------------------
+# Interactive picker
+# ---------------------------------------------------------------------------
+
+
+def _prompt_pick(matches: Sequence[TmyMatch]) -> TmyMatch | None:
+    """Show an indexed list on stderr and prompt for a selection.
+
+    Returns the chosen match, or ``None`` if the user cancels.
+    """
+    color = _stderr_is_tty()
+    print("Multiple matches — pick one:\n", file=sys.stderr)
+    for i, m in enumerate(matches, start=1):
+        s = m.station
+        marker = _style("*", _ANSI_GREEN, _ANSI_BOLD, enabled=color) if i == 1 else " "
+        name = _style(s.display_name, _ANSI_BOLD, enabled=color)
+        wmo = _style(f"WMO {s.wmo}", _ANSI_CYAN, enabled=color)
+        dist = ""
+        if m.distance_km is not None:
+            dist = f"   {m.distance_km:.1f} km"
+        print(f" [{i:>2}] {marker} {name}   {wmo}   {s.dataset_variant}{dist}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    prompt = f"Select 1-{len(matches)} [1], or 'q' to cancel: "
+    try:
+        raw = input(prompt).strip()
+    except (EOFError, KeyboardInterrupt):
+        print("", file=sys.stderr)
+        return None
+
+    if raw.lower() in {"q", "quit", "exit"}:
+        return None
+    if not raw:
+        return matches[0]
+    try:
+        idx = int(raw)
+    except ValueError:
+        _error(f"not a number: {raw!r}")
+        return None
+    if idx < 1 or idx > len(matches):
+        _error(f"selection out of range: {idx}")
+        return None
+    return matches[idx - 1]
+
+
+# ---------------------------------------------------------------------------
+# Action handlers
+# ---------------------------------------------------------------------------
+
+
+def _run_refresh(cfg: TmyRunConfig) -> int:
+    try:
+        index = StationIndex.refresh(cache_dir=cfg.cache_dir)
+    except ImportError as exc:
+        _error(str(exc))
+        return EXIT_USAGE
+    except (HTTPError, URLError, TimeoutError, OSError, RuntimeError) as exc:
+        _error(f"refresh failed: {exc}")
+        return EXIT_NETWORK
+
+    cache = cfg.cache_dir or default_cache_dir()
+    msg = f"Refreshed index: {len(index)} station entries → {cache}/stations.json.gz"
+    if cfg.output.json_output:
+        print(
+            json.dumps(
+                {"stations": len(index), "cache_dir": str(cache), "status": "ok"},
+                indent=2,
+            )
+        )
+    else:
+        print(msg)
+    return EXIT_OK
+
+
+def _run_browse(cfg: TmyRunConfig) -> int:
+    # Imported lazily so that the main path doesn't pay the cost
+    # and so that a broken browser module doesn't break search/download.
+    from ._browser.server import launch_browser
+
+    try:
+        index = StationIndex.load(cache_dir=cfg.cache_dir)
+    except FileNotFoundError as exc:
+        _error(str(exc))
+        return EXIT_USAGE
+
+    return launch_browser(
+        index=index,
+        filters=cfg.filters,
+        browser=cfg.browser,
+        cache_dir=cfg.cache_dir,
+        quiet=cfg.output.quiet,
+    )
+
+
+def _run_list(cfg: TmyRunConfig, matches: Sequence[TmyMatch]) -> int:
+    if not matches:
+        if cfg.output.json_output:
+            print("[]")
+        else:
+            _error("no stations match the given filters")
+        return EXIT_NO_MATCHES
+
+    limited = list(matches[: cfg.output.limit])
+
+    if cfg.output.json_output:
+        print(_format_json(limited))
+        return EXIT_OK
+
+    color = _stdout_is_tty()
+    if not color and not cfg.output.json_output:
+        # Piped without --json → TSV (data-pipe friendly)
+        print(_format_tsv(limited))
+        return EXIT_OK
+
+    # TTY: header on stderr (so stdout stays clean-ish), table on stdout, hint on stderr.
+    if not cfg.output.quiet:
+        print(_format_header(cfg.filters, matches, color=_stderr_is_tty()), file=sys.stderr)
+    print(_format_table(limited, color=color))
+    if len(matches) > cfg.output.limit and not cfg.output.quiet:
+        remaining = len(matches) - cfg.output.limit
+        print(
+            _style(
+                f"… {remaining} more match(es) hidden — raise with --limit N",
+                _ANSI_DIM,
+                enabled=_stderr_is_tty(),
+            ),
+            file=sys.stderr,
+        )
+    if not cfg.output.quiet:
+        print(_next_action_hint(limited, color=_stderr_is_tty()), file=sys.stderr)
+    return EXIT_OK
+
+
+def _pick_download_station(
+    cfg: TmyRunConfig,
+    matches: Sequence[TmyMatch],
+) -> tuple[TmyMatch | None, int | None]:
+    """Choose a single match for download.
+
+    Returns ``(match, None)`` on a successful pick, ``(None, exit_code)``
+    when the caller should abort with the given code, or
+    ``(None, EXIT_OK)`` for a clean user cancellation.
+    """
+    if len(matches) == 1 or cfg.output.first:
+        return matches[0], None
+
+    if _stdout_is_tty() and _stderr_is_tty():
+        picked = _prompt_pick(matches[: cfg.output.limit])
+        if picked is None:
+            _info("Cancelled.", quiet=cfg.output.quiet)
+            return None, EXIT_OK
+        return picked, None
+
+    # Non-TTY: refuse to pick silently.
+    _error(
+        f"{len(matches)} matches; non-interactive session. "
+        "Use --first to pick the top match, or narrow with --wmo / --variant / --country."
+    )
+    preview = matches[: min(5, cfg.output.limit)]
+    for m in preview:
+        s = m.station
+        print(f"  WMO {s.wmo}  {s.display_name}  [{s.dataset_variant}]", file=sys.stderr)
+    return None, EXIT_USAGE
+
+
+def _emit_download_result(
+    cfg: TmyRunConfig,
+    chosen: TmyMatch,
+    files: object,
+) -> None:
+    # ``files`` is a WeatherFiles; typed loosely to avoid a runtime import on this path.
+    epw = getattr(files, "epw")  # noqa: B009
+    ddy = getattr(files, "ddy")  # noqa: B009
+    stat = getattr(files, "stat", None)
+    zip_path = getattr(files, "zip_path")  # noqa: B009
+
+    if cfg.output.json_output:
+        print(
+            json.dumps(
+                {
+                    "station": chosen.station.to_dict(),
+                    "epw": str(epw),
+                    "ddy": str(ddy),
+                    "stat": str(stat) if stat else None,
+                    "zip": str(zip_path),
+                },
+                indent=2,
+            )
+        )
+        return
+
+    color = _stdout_is_tty()
+    print(_style(f"EPW : {epw}", _ANSI_BOLD, enabled=color))
+    print(f"DDY : {ddy}")
+    if stat is not None:
+        print(f"STAT: {stat}")
+    print(_style(f"ZIP : {zip_path}", _ANSI_DIM, enabled=color))
+
+
+def _run_download(cfg: TmyRunConfig, matches: Sequence[TmyMatch]) -> int:
+    from .download import WeatherDownloader
+
+    if not matches:
+        _error("no stations match the given filters; nothing to download")
+        return EXIT_NO_MATCHES
+
+    chosen, exit_code = _pick_download_station(cfg, matches)
+    if chosen is None:
+        return exit_code if exit_code is not None else EXIT_USAGE
+
+    if cfg.download.use_cache:
+        downloader = WeatherDownloader(cache_dir=cfg.cache_dir)
+        target = cfg.cache_dir or default_cache_dir()
+        _info(
+            f"Downloading {chosen.station.display_name} [WMO {chosen.station.wmo}] to cache...",
+            quiet=cfg.output.quiet,
+        )
+    elif cfg.download.dir is not None:
+        downloader = WeatherDownloader(cache_dir=cfg.download.dir)
+        target = cfg.download.dir
+        target.mkdir(parents=True, exist_ok=True)
+        _info(
+            f"Downloading {chosen.station.display_name} [WMO {chosen.station.wmo}] to {target}...",
+            quiet=cfg.output.quiet,
+        )
+    else:  # pragma: no cover - download action without download config is a logic bug
+        _error("internal error: download action without download config")
+        return EXIT_USAGE
+
+    try:
+        files = downloader.download(chosen.station)
+    except RuntimeError as exc:
+        _error(f"download failed: {exc}")
+        return EXIT_NETWORK
+
+    _emit_download_result(cfg, chosen, files)
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry
+# ---------------------------------------------------------------------------
+
+
+def run_tmy(ns: argparse.Namespace) -> int:
+    """Entry point called from the top-level ``idfkit`` CLI dispatcher."""
+    cfg = _namespace_to_config(ns)
+
+    if cfg.errors:
+        for msg in cfg.errors:
+            _error(msg)
+        return EXIT_USAGE
+
+    if cfg.action is TmyAction.REFRESH:
+        return _run_refresh(cfg)
+
+    if cfg.action is TmyAction.BROWSE:
+        return _run_browse(cfg)
+
+    # list / download need at least one filter
+    if not cfg.filters.has_any:
+        _error(
+            "no filters given. Provide a QUERY, --wmo, --filename, --near/--lat/--lon, "
+            "or a metadata filter (--country/--state/--variant). Use --browse for interactive."
+        )
+        return EXIT_USAGE
+
+    try:
+        index = StationIndex.load(cache_dir=cfg.cache_dir)
+    except FileNotFoundError as exc:
+        _error(str(exc))
+        return EXIT_USAGE
+
+    try:
+        matches = _resolve_matches(
+            index,
+            cfg.filters,
+            limit=cfg.output.limit,
+            quiet=cfg.output.quiet,
+        )
+    except GeocodingError as exc:
+        _error(f"geocoding failed: {exc}")
+        return EXIT_NETWORK
+
+    if cfg.action is TmyAction.DOWNLOAD:
+        return _run_download(cfg, matches)
+    return _run_list(cfg, matches)

--- a/tests/test_weather_cli.py
+++ b/tests/test_weather_cli.py
@@ -1,0 +1,542 @@
+"""Tests for idfkit.weather._cli (the ``idfkit tmy`` subcommand)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from idfkit.weather._cli import (
+    EXIT_NETWORK,
+    EXIT_NO_MATCHES,
+    EXIT_OK,
+    EXIT_USAGE,
+    TmyAction,
+    TmyFilters,
+    _format_json,  # pyright: ignore[reportPrivateUsage]
+    _format_tsv,  # pyright: ignore[reportPrivateUsage]
+    _namespace_to_config,  # pyright: ignore[reportPrivateUsage]
+    _resolve_action,  # pyright: ignore[reportPrivateUsage]
+    _resolve_matches,  # pyright: ignore[reportPrivateUsage]
+    _variant_matches,  # pyright: ignore[reportPrivateUsage]
+    add_subparser,
+    run_tmy,
+)
+from idfkit.weather.index import StationIndex
+from idfkit.weather.station import WeatherStation
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _station(
+    *,
+    country: str = "USA",
+    state: str = "IL",
+    city: str = "Chicago.Ohare.Intl.AP",
+    wmo: str = "725300",
+    lat: float = 41.98,
+    lon: float = -87.92,
+    variant: str = "TMYx.2009-2023",
+    source: str = "SRC-TMYx",
+) -> WeatherStation:
+    base = "https://climate.onebuilding.org/WMO_Region_4/"
+    url = f"{base}{country}_{state}_{city}.{wmo}_{variant}.zip"
+    return WeatherStation(
+        country=country,
+        state=state,
+        city=city,
+        wmo=wmo,
+        source=source,
+        latitude=lat,
+        longitude=lon,
+        timezone=-6.0,
+        elevation=200.0,
+        url=url,
+    )
+
+
+@pytest.fixture
+def sample_index() -> StationIndex:
+    return StationIndex.from_stations([
+        _station(wmo="725300", variant="TMYx"),
+        _station(wmo="725300", variant="TMYx.2009-2023"),
+        _station(wmo="725300", variant="TMYx.2007-2021"),
+        _station(city="Chicago.Midway.AP", wmo="725340", variant="TMYx.2009-2023", lat=41.79, lon=-87.75),
+        _station(
+            country="GBR",
+            state="",
+            city="London.Heathrow.AP",
+            wmo="037720",
+            variant="TMYx",
+            lat=51.48,
+            lon=-0.45,
+        ),
+    ])
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    """Build a parser with just the tmy subcommand and parse *argv*."""
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers(dest="command")
+    add_subparser(sub)
+    return top.parse_args(["tmy", *argv])
+
+
+# ---------------------------------------------------------------------------
+# Namespace → config translation
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceToConfig:
+    def test_query_only_yields_list_action(self) -> None:
+        ns = _parse(["chicago"])
+        cfg = _namespace_to_config(ns)
+        assert cfg.action is TmyAction.LIST
+        assert cfg.filters.query == "chicago"
+
+    def test_download_sentinel_means_cache(self) -> None:
+        ns = _parse(["chicago", "--download"])
+        cfg = _namespace_to_config(ns)
+        assert cfg.action is TmyAction.DOWNLOAD
+        assert cfg.download.use_cache is True
+        assert cfg.download.dir is None
+
+    def test_download_with_dir(self, tmp_path: Path) -> None:
+        ns = _parse(["chicago", "--download", str(tmp_path)])
+        cfg = _namespace_to_config(ns)
+        assert cfg.action is TmyAction.DOWNLOAD
+        assert cfg.download.use_cache is False
+        assert cfg.download.dir == tmp_path
+
+    def test_browse_action(self) -> None:
+        ns = _parse(["--browse"])
+        cfg = _namespace_to_config(ns)
+        assert cfg.action is TmyAction.BROWSE
+
+    def test_refresh_action(self) -> None:
+        ns = _parse(["--refresh"])
+        cfg = _namespace_to_config(ns)
+        assert cfg.action is TmyAction.REFRESH
+
+    def test_near_and_lat_lon_conflict(self) -> None:
+        ns = _parse(["--near", "NYC", "--lat", "40.7", "--lon", "-74.0"])
+        cfg = _namespace_to_config(ns)
+        assert any("--near" in e for e in cfg.errors)
+
+    def test_partial_lat_lon_errors(self) -> None:
+        ns = _parse(["--lat", "40.7"])
+        cfg = _namespace_to_config(ns)
+        assert any("--lat and --lon" in e for e in cfg.errors)
+
+    def test_max_km_without_spatial_errors(self) -> None:
+        ns = _parse(["chicago", "--max-km", "50"])
+        cfg = _namespace_to_config(ns)
+        assert any("--max-km" in e for e in cfg.errors)
+
+    def test_full_filters(self) -> None:
+        ns = _parse([
+            "chicago",
+            "--country",
+            "USA",
+            "--state",
+            "IL",
+            "--variant",
+            "2009-2023",
+            "--limit",
+            "3",
+            "--json",
+        ])
+        cfg = _namespace_to_config(ns)
+        assert cfg.filters.query == "chicago"
+        assert cfg.filters.country == "USA"
+        assert cfg.filters.state == "IL"
+        assert cfg.filters.variant == "2009-2023"
+        assert cfg.output.limit == 3
+        assert cfg.output.json_output is True
+
+
+class TestResolveAction:
+    def test_refresh_beats_browse(self) -> None:
+        # Mutex group prevents both via argparse; exercise internal precedence directly.
+        ns = argparse.Namespace(refresh=True, browse=True, download=None)
+        assert _resolve_action(ns) is TmyAction.REFRESH
+
+    def test_browse_beats_download(self) -> None:
+        ns = argparse.Namespace(refresh=False, browse=True, download="./dl")
+        assert _resolve_action(ns) is TmyAction.BROWSE
+
+    def test_default_is_list(self) -> None:
+        ns = argparse.Namespace(refresh=False, browse=False, download=None)
+        assert _resolve_action(ns) is TmyAction.LIST
+
+
+# ---------------------------------------------------------------------------
+# Filter resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMatches:
+    def test_wmo_returns_all_variants(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(sample_index, TmyFilters(wmo="725300"), limit=10, quiet=True)
+        assert len(matches) == 3
+        assert all(m.station.wmo == "725300" for m in matches)
+        assert all(m.match_field == "wmo" for m in matches)
+
+    def test_wmo_plus_variant_narrows(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(
+            sample_index,
+            TmyFilters(wmo="725300", variant="2009-2023"),
+            limit=10,
+            quiet=True,
+        )
+        assert len(matches) == 1
+        assert matches[0].station.dataset_variant == "TMYx.2009-2023"
+
+    def test_query_returns_scored_results(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(sample_index, TmyFilters(query="chicago ohare"), limit=10, quiet=True)
+        assert len(matches) >= 1
+        assert all(m.score is not None for m in matches)
+        # Top result should be Chicago Ohare
+        assert "Ohare" in matches[0].station.city
+
+    def test_spatial_uses_coords(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(
+            sample_index,
+            TmyFilters(lat=41.9, lon=-87.8, max_km=50),
+            limit=10,
+            quiet=True,
+        )
+        assert len(matches) >= 1
+        assert all(m.distance_km is not None for m in matches)
+        # All Chicago stations, none London
+        for m in matches:
+            assert m.station.country == "USA"
+            assert m.station.state == "IL"
+
+    def test_country_post_filter(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(sample_index, TmyFilters(country="GBR"), limit=10, quiet=True)
+        assert len(matches) == 1
+        assert matches[0].station.country == "GBR"
+
+    def test_state_post_filter(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(
+            sample_index,
+            TmyFilters(country="USA", state="IL"),
+            limit=10,
+            quiet=True,
+        )
+        assert {m.station.city for m in matches} == {
+            "Chicago.Ohare.Intl.AP",
+            "Chicago.Midway.AP",
+        }
+
+    def test_variant_substring(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(sample_index, TmyFilters(variant="2009"), limit=10, quiet=True)
+        # Only the TMYx.2009-2023 variants
+        assert all("2009" in m.station.dataset_variant for m in matches)
+
+    def test_filename_lookup(self, sample_index: StationIndex) -> None:
+        # Pick a filename stem we know is indexed
+        any_station = sample_index.stations[0]
+        matches = _resolve_matches(
+            sample_index,
+            TmyFilters(filename=any_station.filename_stem),
+            limit=10,
+            quiet=True,
+        )
+        assert len(matches) >= 1
+        assert all(m.match_field == "filename" for m in matches)
+
+
+class TestVariantMatches:
+    def test_substring_case_insensitive(self) -> None:
+        s = _station(variant="TMYx.2009-2023")
+        assert _variant_matches(s, "tmyx")
+        assert _variant_matches(s, "2009-2023")
+        assert _variant_matches(s, "TMYx.2009")
+        assert not _variant_matches(s, "2007-2021")
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+class TestFormatters:
+    def test_json_roundtrip(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(sample_index, TmyFilters(wmo="725300"), limit=10, quiet=True)
+        out = _format_json(matches)
+        parsed = json.loads(out)
+        assert len(parsed) == 3
+        assert parsed[0]["station"]["wmo"] == "725300"
+
+    def test_tsv_header_and_rows(self, sample_index: StationIndex) -> None:
+        matches = _resolve_matches(sample_index, TmyFilters(wmo="725300"), limit=10, quiet=True)
+        out = _format_tsv(matches)
+        lines = out.split("\n")
+        assert lines[0].startswith("country\tstate\tcity\twmo")
+        assert len(lines) == 4  # header + 3 variants
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run_tmy via stubbed index
+# ---------------------------------------------------------------------------
+
+
+class TestRunTmy:
+    def test_no_filters_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ns = _parse([])
+        code = run_tmy(ns)
+        assert code == EXIT_USAGE
+        err = capsys.readouterr().err
+        assert "no filters given" in err
+
+    def test_conflicting_flags_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ns = _parse(["--near", "Paris", "--lat", "48.8", "--lon", "2.3"])
+        code = run_tmy(ns)
+        assert code == EXIT_USAGE
+        assert "--near" in capsys.readouterr().err
+
+    def test_wmo_json_output(
+        self,
+        sample_index: StationIndex,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--wmo", "725300", "--json"])
+        with patch.object(StationIndex, "load", return_value=sample_index):
+            code = run_tmy(ns)
+        assert code == EXIT_OK
+        parsed = json.loads(capsys.readouterr().out)
+        assert len(parsed) == 3
+
+    def test_no_matches_returns_exit_1(
+        self,
+        sample_index: StationIndex,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--wmo", "999999", "--json"])
+        with patch.object(StationIndex, "load", return_value=sample_index):
+            code = run_tmy(ns)
+        assert code == EXIT_NO_MATCHES
+        assert capsys.readouterr().out.strip() == "[]"
+
+    def test_download_nontty_multiple_matches_errors(
+        self,
+        sample_index: StationIndex,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--wmo", "725300", "--download"])
+        with patch.object(StationIndex, "load", return_value=sample_index):
+            code = run_tmy(ns)
+        # 3 variants, no --first, not a TTY in pytest → usage error
+        assert code == EXIT_USAGE
+        err = capsys.readouterr().err
+        assert "non-interactive" in err or "--first" in err
+
+    def test_download_first_picks_top(
+        self,
+        sample_index: StationIndex,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--wmo", "725300", "--first", "--download", str(tmp_path), "--json"])
+
+        fake_files = MagicMock()
+        fake_files.epw = tmp_path / "station.epw"
+        fake_files.ddy = tmp_path / "station.ddy"
+        fake_files.stat = tmp_path / "station.stat"
+        fake_files.zip_path = tmp_path / "station.zip"
+
+        with (
+            patch.object(StationIndex, "load", return_value=sample_index),
+            patch("idfkit.weather.download.WeatherDownloader.download", return_value=fake_files) as dl,
+        ):
+            code = run_tmy(ns)
+        assert code == EXIT_OK
+        dl.assert_called_once()
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["station"]["wmo"] == "725300"
+        assert parsed["epw"].endswith("station.epw")
+
+    def test_download_network_failure_returns_exit_3(
+        self,
+        sample_index: StationIndex,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--wmo", "725300", "--first", "--download", str(tmp_path)])
+        with (
+            patch.object(StationIndex, "load", return_value=sample_index),
+            patch(
+                "idfkit.weather.download.WeatherDownloader.download",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            code = run_tmy(ns)
+        assert code == EXIT_NETWORK
+        assert "boom" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Browser server smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserServer:
+    def test_endpoints(self, sample_index: StationIndex) -> None:
+        """Launch the server on a random port and hit the key endpoints."""
+        import http.client
+        import json as _json
+        import threading
+        import time
+        from http.server import ThreadingHTTPServer
+
+        from idfkit.weather._browser.server import (
+            BrowserState,
+            _make_handler,  # pyright: ignore[reportPrivateUsage]
+        )
+        from idfkit.weather._cli import TmyFilters
+
+        state = BrowserState(
+            index=sample_index,
+            filters=TmyFilters(query="chicago"),
+            cache_dir=None,
+            quiet=True,
+        )
+        handler_cls = _make_handler(state)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            # Give the OS a tick to bind
+            time.sleep(0.05)
+
+            # /api/config returns the seeded filters
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/api/config")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            payload = _json.loads(resp.read().decode())
+            assert payload["query"] == "chicago"
+            conn.close()
+
+            # /stations.json.gz serves gzip bytes (first two bytes are the gzip magic)
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/stations.json.gz")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            assert resp.getheader("Content-Encoding") == "gzip"
+            body = resp.read()
+            assert body[:2] == b"\x1f\x8b"
+            conn.close()
+
+            # / returns the HTML
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/")
+            resp = conn.getresponse()
+            assert resp.status == 200
+            html = resp.read().decode()
+            assert "<title>idfkit tmy" in html
+            conn.close()
+
+            # Unknown path → 404
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/nope")
+            resp = conn.getresponse()
+            assert resp.status == 404
+            conn.close()
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_zip_endpoint_streams_attachment(
+        self,
+        sample_index: StationIndex,
+        tmp_path: Path,
+    ) -> None:
+        """``GET /api/zip`` should stream the cached ZIP with an attachment header."""
+        import http.client
+        import threading
+        import time
+        from http.server import ThreadingHTTPServer
+        from unittest.mock import MagicMock, patch
+
+        from idfkit.weather._browser.server import (
+            BrowserState,
+            _make_handler,  # pyright: ignore[reportPrivateUsage]
+        )
+        from idfkit.weather._cli import TmyFilters
+
+        zip_bytes = b"PK\x03\x04fake-zip-body"
+        zip_path = tmp_path / "USA_IL_Chicago.Ohare.Intl.AP.725300_TMYx.zip"
+        zip_path.write_bytes(zip_bytes)
+        fake_files = MagicMock()
+        fake_files.zip_path = zip_path
+
+        state = BrowserState(
+            index=sample_index,
+            filters=TmyFilters(),
+            cache_dir=tmp_path,
+            quiet=True,
+        )
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(state))
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            time.sleep(0.05)
+            with patch(
+                "idfkit.weather.download.WeatherDownloader.download",
+                return_value=fake_files,
+            ) as dl:
+                conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+                conn.request("GET", "/api/zip?wmo=725300")
+                resp = conn.getresponse()
+                assert resp.status == 200
+                assert resp.getheader("Content-Type") == "application/zip"
+                disposition = resp.getheader("Content-Disposition") or ""
+                assert "attachment" in disposition
+                assert zip_path.name in disposition
+                body = resp.read()
+                assert body == zip_bytes
+                conn.close()
+                dl.assert_called_once()
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_zip_endpoint_missing_params(self, sample_index: StationIndex) -> None:
+        import http.client
+        import threading
+        import time
+        from http.server import ThreadingHTTPServer
+
+        from idfkit.weather._browser.server import (
+            BrowserState,
+            _make_handler,  # pyright: ignore[reportPrivateUsage]
+        )
+        from idfkit.weather._cli import TmyFilters
+
+        state = BrowserState(index=sample_index, filters=TmyFilters(), cache_dir=None, quiet=True)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(state))
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            time.sleep(0.05)
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", "/api/zip")
+            resp = conn.getresponse()
+            assert resp.status == 400
+            conn.close()
+        finally:
+            server.shutdown()
+            server.server_close()


### PR DESCRIPTION
## Summary

- New `idfkit tmy` CLI subcommand wrapping the bundled TMYx station index: search, download, interactive map browser, and index refresh — all stdlib-only (no new runtime deps).
- Ships an `http.server`-based web UI (`--browse`) at `src/idfkit/weather/_browser/` with a Leaflet/MarkerCluster map over ~17k stations, backed by a tiny REST shim (`/stations.json.gz`, `/api/config`, `/api/zip`).
- 33 new tests covering namespace→config translation, filter resolution, formatters, end-to-end `run_tmy` with mocked downloader, and two real-socket browser-server smoke tests.

## Usage

```bash
idfkit tmy "chicago ohare"
idfkit tmy --near "350 Fifth Ave, NYC" --max-km 25
idfkit tmy --wmo 725300 --variant 2009-2023 --download ./weather/
idfkit tmy "london" --first --download
idfkit tmy --browse
idfkit tmy --refresh
```

Output is TTY-aware (coloured table on TTY, TSV on pipe, JSON on `--json`), progress is written to stderr, and exit codes follow a documented contract: `0` ok / `1` no matches / `2` usage / `3` network.

## Design notes

- Typed dataclasses (`TmyFilters`, `TmyOutputConfig`, `TmyDownloadConfig`, `TmyBrowserConfig`, `TmyRunConfig`) instead of raw argparse namespaces — cross-flag validation errors are collected upfront rather than thrown mid-flow.
- Browser UI is self-contained: vendored `app.js`/`index.html`/`style.css`, Leaflet + MarkerCluster pulled from unpkg (Leaflet with SRI). The server never calls back into the main CLI; it is a separate module loaded lazily.
- `/api/zip` proxies the ZIP through `WeatherDownloader` server-side so the cache stays shared between CLI and browser downloads.

## Test plan

- [x] `uv run pytest tests/test_weather_cli.py -q` — 33 passed
- [x] `uv run ruff check src/idfkit/weather/ tests/test_weather_cli.py` — clean
- [x] `uv run ruff format --check` on new files — clean
- [x] `uv run pyright src/idfkit/weather/_cli.py src/idfkit/weather/_browser/` — 0 errors
- [x] Manual smoke: `idfkit tmy "chicago"` on a TTY
- [x] Manual smoke: `idfkit tmy --browse` — map renders, marker click opens detail, download lands in cache
- [x] Manual smoke: `idfkit tmy --wmo 725300 --first --download ./tmp/` — EPW/DDY/STAT extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)