### PR TITLE
feat(cli): add `idfkit tmy --nearby` to auto-detect location from IP

### DIFF
--- a/docs/api/weather/index.md
+++ b/docs/api/weather/index.md
@@ -14,6 +14,7 @@ The weather module provides station search, file downloads, and design day manag
 | [`DesignDayType`](designday.md) | Design day type enumeration |
 | [`apply_ashrae_sizing()`](designday.md) | Quick design day application |
 | [`geocode()`](station.md) | Address to coordinates |
+| [`detect_location()`](station.md) | This machine's coordinates from public IP |
 
 ## Module Contents
 

--- a/docs/cli/tmy.md
+++ b/docs/cli/tmy.md
@@ -20,16 +20,46 @@ Output is TTY-aware: coloured table on a terminal, TSV when piped, JSON with `--
 | `--wmo WMO` | Exact WMO station number lookup (e.g. `725300`) |
 | `--filename NAME` | Exact EPW filename or stem lookup |
 | `--near ADDRESS` | Geocode an address (Nominatim), then rank by distance |
+| `--nearby` | Auto-detect coordinates from your public IP, then rank by distance |
 | `--lat LAT --lon LON` | Spatial anchor by explicit coordinates |
-| `--max-km KM` | Cap distance for `--near` / `--lat`+`--lon` |
+| `--max-km KM` | Cap distance for any spatial anchor |
 | `--country CC` | ISO country code (`USA`, `FRA`, `GBR`, …) |
 | `--state ST` | State/province code |
 | `--variant STR` | Substring match on dataset variant (`TMYx.2009-2023`, `2009-2023`, …) |
 
-`--near` cannot be combined with `--lat`/`--lon`, and `--lat`/`--lon` must be specified together. `--max-km` requires a spatial anchor.
+The three spatial anchors — `--near`, `--nearby`, and `--lat`/`--lon` — are
+mutually exclusive, and `--lat`/`--lon` must be specified together.
+`--max-km` requires one of them.
 
 !!! note "No climate-zone filter"
     There is no `--climate-zone` flag because the upstream station index on climate.onebuilding.org does not publish climate zones per station. To pick a station for a specific ASHRAE zone, look up a representative city for that zone and use `--near "<city>"`. See [Weather Pipeline: No Climate Zone Filter](../concepts/weather-pipeline.md#no-climate-zone-filter) for the full rationale.
+
+## Detect location from IP (`--nearby`)
+
+`--nearby` is a zero-input shortcut for "stations near me". It resolves
+the running machine's approximate coordinates from its public IP via
+[ipapi.co](https://ipapi.co/) and feeds them straight into the same
+spatial pipeline as `--near` and `--lat`/`--lon`.
+
+```bash
+# 10 closest stations to here
+idfkit tmy --nearby
+
+# Bound the search and grab the top match into the platform cache
+idfkit tmy --nearby --max-km 50 --first --download
+
+# Filter by country at the same time
+idfkit tmy --nearby --country USA --max-km 100 --json
+```
+
+Calls hit ipapi.co over HTTPS and the result is **cached on disk for one
+hour** under the platform weather cache directory, so repeated
+invocations don't make repeated network calls. Accuracy is city-level —
+fine for picking a TMYx station, not precise enough for surveying.
+
+If you'd rather not send your IP to ipapi.co, use `--near "<city>"` or
+`--lat`/`--lon` instead. The Python equivalent is
+[`detect_location()`](../weather/geocoding.md#detect-location-from-ip).
 
 ## Download
 
@@ -98,6 +128,7 @@ Rebuilds the bundled index from the live Excel files on climate.onebuilding.org.
 | `--wmo WMO` | — | Exact WMO lookup |
 | `--filename NAME` | — | Exact filename/stem lookup |
 | `--near ADDR` | — | Geocode then rank by distance |
+| `--nearby` | `false` | Auto-detect coordinates from your IP (cached 1h) |
 | `--lat LAT` / `--lon LON` | — | Explicit coordinates (decimal degrees) |
 | `--max-km KM` | — | Distance cap for spatial searches |
 | `--country CC` | — | ISO country filter |
@@ -119,5 +150,5 @@ Rebuilds the bundled index from the live Excel files on climate.onebuilding.org.
 
 - [Weather Downloads](../weather/downloads.md) — the `WeatherDownloader` Python API the CLI wraps
 - [Station Search](../weather/station-search.md) — the `StationIndex` Python API
-- [Geocoding](../weather/geocoding.md) — `--near` uses the same Nominatim client as `geocode()`
+- [Geocoding](../weather/geocoding.md) — `--near` uses `geocode()`; `--nearby` uses `detect_location()`
 - [Weather Pipeline](../concepts/weather-pipeline.md) — architectural overview

--- a/docs/snippets/weather/geocoding/detect_location_basic.py
+++ b/docs/snippets/weather/geocoding/detect_location_basic.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+lat: float = ...  # type: ignore[assignment]
+lon: float = ...  # type: ignore[assignment]
+# --8<-- [start:example]
+from idfkit.weather import detect_location
+
+# Detect approximate coordinates from this machine's public IP.
+# Sent over HTTPS to ipapi.co; result cached on disk for 1 hour.
+lat, lon = detect_location()
+print(f"Approximate location: {lat:.4f}, {lon:.4f}")
+# --8<-- [end:example]

--- a/docs/snippets/weather/geocoding/detect_location_caching.py
+++ b/docs/snippets/weather/geocoding/detect_location_caching.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+lat: float = ...  # type: ignore[assignment]
+lon: float = ...  # type: ignore[assignment]
+# --8<-- [start:example]
+from idfkit.weather import detect_location
+
+# Default: cache for 1 hour in the platform weather cache directory.
+lat, lon = detect_location()
+
+# Cache for 24 hours instead.
+lat, lon = detect_location(max_age=timedelta(hours=24))
+
+# Always re-fetch (skip the cache).
+lat, lon = detect_location(max_age=0)
+
+# Cache forever (until the file is deleted).
+lat, lon = detect_location(max_age=None)
+
+# Use a custom cache directory.
+lat, lon = detect_location(cache_dir=Path("/tmp/my-cache"))
+# --8<-- [end:example]

--- a/docs/snippets/weather/geocoding/detect_location_error_handling.py
+++ b/docs/snippets/weather/geocoding/detect_location_error_handling.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+# --8<-- [start:example]
+from idfkit.weather import GeocodingError, detect_location
+
+try:
+    lat, lon = detect_location()
+except GeocodingError as e:
+    # Network failure, ipapi.co rate limit, or unrecognised IP.
+    print(f"Could not detect location: {e}")
+    # Fall back to an explicit prompt or a hard-coded default.
+    lat, lon = 41.85, -87.65  # Chicago
+# --8<-- [end:example]

--- a/docs/snippets/weather/geocoding/detect_location_with_station_search.py
+++ b/docs/snippets/weather/geocoding/detect_location_with_station_search.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from idfkit.weather import StationIndex, WeatherStation
+
+index: StationIndex = ...  # type: ignore[assignment]
+station: WeatherStation = ...  # type: ignore[assignment]
+# --8<-- [start:example]
+from idfkit.weather import StationIndex, detect_location
+
+index = StationIndex.load()
+
+# "Find weather stations near me" — one liner using the splat operator.
+results = index.nearest(*detect_location())
+
+station = results[0].station
+print(f"Nearest: {station.display_name} ({results[0].distance_km:.1f} km)")
+# --8<-- [end:example]

--- a/docs/weather/geocoding.md
+++ b/docs/weather/geocoding.md
@@ -1,7 +1,16 @@
 # Geocoding
 
-The `geocode()` function converts addresses to coordinates using the free
-Nominatim (OpenStreetMap) service.
+The weather module provides two ways to resolve coordinates without
+hard-coding them:
+
+- [`geocode(address)`](#basic-usage) — convert a known street address to
+  `(lat, lon)` via the free Nominatim (OpenStreetMap) service.
+- [`detect_location()`](#detect-location-from-ip) — auto-detect the
+  current machine's approximate coordinates from its public IP.
+
+Both return a `(latitude, longitude)` tuple and raise `GeocodingError` on
+failure, so they compose interchangeably with
+[`StationIndex.nearest()`](station-search.md).
 
 ## Basic Usage
 
@@ -84,8 +93,63 @@ If you already know the coordinates, skip geocoding entirely:
 --8<-- "docs/snippets/weather/geocoding/alternative_direct_coordinates.py:example"
 ```
 
+## Detect Location from IP
+
+`detect_location()` resolves the running machine's approximate
+coordinates from its public IP, so callers don't need to know or supply
+an address. It's the "weather stations near me" companion to `geocode()`.
+
+```python
+--8<-- "docs/snippets/weather/geocoding/detect_location_basic.py:example"
+```
+
+### Combining with Station Search
+
+Like `geocode()`, the result splats directly into
+[`StationIndex.nearest()`](station-search.md):
+
+```python
+--8<-- "docs/snippets/weather/geocoding/detect_location_with_station_search.py:example"
+```
+
+The same flow is exposed on the CLI as
+[`idfkit tmy --nearby`](../cli/tmy.md#detect-location-from-ip-nearby).
+
+### Caching
+
+Calls hit `ipapi.co` over HTTPS and the result is cached on disk for
+**1 hour** by default. Repeated calls within that window return the
+cached value with no network access. The cache file lives under the same
+platform cache directory used by `WeatherDownloader` (e.g.
+`~/.cache/idfkit/weather/ipgeo.json` on Linux), and the TTL and location
+are both configurable:
+
+```python
+--8<-- "docs/snippets/weather/geocoding/detect_location_caching.py:example"
+```
+
+### Error Handling
+
+`detect_location()` raises [`GeocodingError`][idfkit.weather.geocode.GeocodingError]
+on any failure — network outage, ipapi.co rate limit, or an
+unlocatable IP (e.g. some VPNs):
+
+```python
+--8<-- "docs/snippets/weather/geocoding/detect_location_error_handling.py:example"
+```
+
+### Privacy and Accuracy Notes
+
+- Calling `detect_location()` sends your machine's public IP address to
+  [ipapi.co](https://ipapi.co/) over HTTPS. If you'd rather not, use
+  `geocode("city, country")` or pass coordinates directly.
+- Accuracy is **city-level**. That is sufficient for choosing a TMYx
+  station within ~50 km, but not for precise positioning.
+- The cache is on the local filesystem; nothing is sent anywhere else.
+
 ## See Also
 
 - [Station Search](station-search.md) — Find weather stations
 - [Weather Downloads](downloads.md) — Download weather files
 - [Weather Overview](index.md) — Module overview
+- [`idfkit tmy --nearby`](../cli/tmy.md#detect-location-from-ip-nearby) — CLI shortcut around `detect_location()`

--- a/docs/weather/index.md
+++ b/docs/weather/index.md
@@ -48,6 +48,20 @@ Find the nearest weather station to any address:
 --8<-- "docs/snippets/weather/index/address_based_search.py:example"
 ```
 
+### "Nearest to me" — Auto-Detected Location
+
+Skip the address entirely and let `detect_location()` resolve the
+machine's coordinates from its public IP (cached on disk for 1 hour):
+
+```python
+--8<-- "docs/snippets/weather/geocoding/detect_location_with_station_search.py:example"
+```
+
+The CLI exposes the same flow as
+[`idfkit tmy --nearby`](../cli/tmy.md#detect-location-from-ip-nearby).
+See [Geocoding](geocoding.md#detect-location-from-ip) for caching, error
+handling, and privacy notes.
+
 ### ASHRAE Design Days
 
 Apply standard design day conditions to your model:
@@ -64,6 +78,7 @@ Apply standard design day conditions to your model:
 | [`WeatherDownloader`](downloads.md) | Download EPW and DDY files |
 | [`DesignDayManager`](design-days.md) | Parse and apply design days |
 | [`geocode()`](geocoding.md) | Convert addresses to coordinates |
+| [`detect_location()`](geocoding.md#detect-location-from-ip) | Auto-detect coordinates from this machine's public IP |
 | [`idfkit tmy`](../cli/tmy.md) | Search, download, and browse TMYx data from the shell |
 
 ## Installation

--- a/src/idfkit/weather/__init__.py
+++ b/src/idfkit/weather/__init__.py
@@ -96,7 +96,7 @@ from __future__ import annotations
 from ..exceptions import NoDesignDaysError
 from .designday import DesignDayManager, DesignDayType, apply_ashrae_sizing
 from .download import WeatherDownloader, WeatherFiles
-from .geocode import GeocodingError, geocode
+from .geocode import GeocodingError, detect_location, geocode
 from .index import StationIndex
 from .station import SearchResult, SpatialResult, WeatherStation
 
@@ -112,5 +112,6 @@ __all__ = [
     "WeatherFiles",
     "WeatherStation",
     "apply_ashrae_sizing",
+    "detect_location",
     "geocode",
 ]

--- a/src/idfkit/weather/_cli.py
+++ b/src/idfkit/weather/_cli.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 
-from .geocode import GeocodingError, geocode
+from .geocode import GeocodingError, detect_location, geocode
 from .index import StationIndex, default_cache_dir
 
 if TYPE_CHECKING:
@@ -65,14 +65,15 @@ class TmyFilters:
     country: str | None = None
     state: str | None = None
     variant: str | None = None
+    nearby: bool = False
 
     @property
     def has_spatial(self) -> bool:
-        return self.near is not None or (self.lat is not None and self.lon is not None)
+        return self.near is not None or (self.lat is not None and self.lon is not None) or self.nearby
 
     @property
     def has_any(self) -> bool:
-        return any(
+        return self.nearby or any(
             v is not None
             for v in (
                 self.query,
@@ -149,6 +150,7 @@ _EPILOG = """\
 examples:
   idfkit tmy "chicago ohare"
   idfkit tmy --near "350 Fifth Ave, NYC" --max-km 25
+  idfkit tmy --nearby --max-km 50 --first --download
   idfkit tmy --wmo 725300 --variant 2009-2023 --download ./weather/
   idfkit tmy "london" --first --download
   idfkit tmy --browse
@@ -190,6 +192,15 @@ def add_subparser(
     p.add_argument("--filename", metavar="NAME", help="Exact EPW filename or stem")
 
     p.add_argument("--near", metavar="ADDRESS", help="Geocode address, then find nearest stations")
+    p.add_argument(
+        "--nearby",
+        action="store_true",
+        help=(
+            "Auto-detect coordinates from your public IP "
+            "(sent over HTTPS to ipapi.co; cached locally for 1h) "
+            "and find nearest stations"
+        ),
+    )
     p.add_argument("--lat", type=float, metavar="LAT", help="Latitude (decimal degrees, N positive)")
     p.add_argument("--lon", type=float, metavar="LON", help="Longitude (decimal degrees, E positive)")
     p.add_argument("--max-km", dest="max_km", type=float, metavar="KM", help="Maximum distance in km")
@@ -283,15 +294,20 @@ def _namespace_to_config(ns: argparse.Namespace) -> TmyRunConfig:
         country=getattr(ns, "country", None),
         state=getattr(ns, "state", None),
         variant=getattr(ns, "variant", None),
+        nearby=bool(getattr(ns, "nearby", False)),
     )
 
     # Cross-flag validation
     if filters.near is not None and (filters.lat is not None or filters.lon is not None):
         errors.append("--near cannot be combined with --lat/--lon")
+    if filters.nearby and filters.near is not None:
+        errors.append("--nearby cannot be combined with --near")
+    if filters.nearby and (filters.lat is not None or filters.lon is not None):
+        errors.append("--nearby cannot be combined with --lat/--lon")
     if (filters.lat is None) != (filters.lon is None):
         errors.append("--lat and --lon must be specified together")
     if filters.max_km is not None and not filters.has_spatial:
-        errors.append("--max-km requires --near or --lat/--lon")
+        errors.append("--max-km requires --near, --nearby, or --lat/--lon")
 
     action = _resolve_action(ns)
 
@@ -379,13 +395,18 @@ def _post_filter(matches: Sequence[TmyMatch], filters: TmyFilters) -> list[TmyMa
 
 
 def _resolve_coords(filters: TmyFilters, *, quiet: bool) -> tuple[float, float] | None:
-    """Resolve the spatial anchor from ``--near`` or ``--lat/--lon``.
+    """Resolve the spatial anchor from ``--nearby``, ``--near``, or ``--lat/--lon``.
 
     Returns ``None`` when no spatial filter is active. Raises
-    :class:`GeocodingError` on geocoding failure.
+    :class:`GeocodingError` on geocoding / IP-detection failure.
     """
     if filters.lat is not None and filters.lon is not None:
         return filters.lat, filters.lon
+    if filters.nearby:
+        _info("Detecting location from IP via ipapi.co...", quiet=quiet)
+        lat, lon = detect_location()
+        _info(f"Detected approximate location: {lat:.4f}, {lon:.4f}", quiet=quiet)
+        return lat, lon
     if filters.near is not None:
         _info(f"Geocoding '{filters.near}' via Nominatim...", quiet=quiet)
         return geocode(filters.near)
@@ -543,6 +564,17 @@ def _format_table(matches: Sequence[TmyMatch], *, color: bool) -> str:
     return "\n".join(lines)
 
 
+def _spatial_anchor_bit(filters: TmyFilters) -> str | None:
+    """One-line description of the spatial anchor, or ``None`` if absent."""
+    if filters.near:
+        return f'near="{filters.near}"'
+    if filters.lat is not None and filters.lon is not None:
+        return f"coords={filters.lat:.4f},{filters.lon:.4f}"
+    if filters.nearby:
+        return "nearby=ip"
+    return None
+
+
 def _format_header(filters: TmyFilters, matches: Sequence[TmyMatch], *, color: bool) -> str:
     bits: list[str] = []
     if filters.query:
@@ -551,10 +583,9 @@ def _format_header(filters: TmyFilters, matches: Sequence[TmyMatch], *, color: b
         bits.append(f"wmo={filters.wmo}")
     if filters.filename:
         bits.append(f"filename={filters.filename}")
-    if filters.near:
-        bits.append(f'near="{filters.near}"')
-    elif filters.lat is not None and filters.lon is not None:
-        bits.append(f"coords={filters.lat:.4f},{filters.lon:.4f}")
+    spatial = _spatial_anchor_bit(filters)
+    if spatial is not None:
+        bits.append(spatial)
     if filters.max_km is not None:
         bits.append(f"max_km={filters.max_km}")
     if filters.country:

--- a/src/idfkit/weather/geocode.py
+++ b/src/idfkit/weather/geocode.py
@@ -7,10 +7,32 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.error import URLError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 _NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 _USER_AGENT = "idfkit (https://github.com/idfkit/idfkit)"
+
+# IP-geolocation endpoint used by detect_location().
+#
+# Provider rationale (evaluated April 2026):
+#   * ipapi.co — HTTPS, no key, ~1000 req/IP/day free tier, JSON with
+#     ``latitude``/``longitude`` keys. Picked as primary.
+#   * ip-api.com — free tier is HTTP-only (HTTPS requires Pro), so unsuitable
+#     for a tool that ships to users.
+#   * freeipapi.com — HTTPS, no key, 60 req/min/IP. Reasonable fallback.
+#   * ipinfo.io — needs a token for sustained use; free tier limited.
+#
+# A future maintainer can swap providers by changing _IPAPI_URL and the
+# response-parsing keys in detect_location(); the rest of the contract
+# (return type, GeocodingError on failure) is provider-agnostic.
+_IPAPI_URL = "https://ipapi.co/json/"
+_IPGEO_CACHE_FILENAME = "ipgeo.json"
 
 
 class GeocodingError(Exception):
@@ -51,6 +73,10 @@ class RateLimiter:
 
 # Global rate limiter instance for Nominatim (1 request per second)
 _nominatim_limiter = RateLimiter(min_interval=1.0)
+
+# Global rate limiter for ipapi.co (1 request per second is well under the
+# free-tier ~1000/day limit and matches the courtesy used for Nominatim).
+_ipapi_limiter = RateLimiter(min_interval=1.0)
 
 
 def geocode(address: str) -> tuple[float, float]:
@@ -109,3 +135,139 @@ def geocode(address: str) -> tuple[float, float]:
         raise GeocodingError(msg) from exc
     msg = f"No results found for address: {address}"
     raise GeocodingError(msg)
+
+
+def _max_age_seconds(max_age: timedelta | float | None) -> float | None:
+    if max_age is None:
+        return None
+    if isinstance(max_age, timedelta):
+        return max_age.total_seconds()
+    return float(max_age)
+
+
+def _read_ipgeo_cache(path: Path, max_age_seconds: float | None) -> tuple[float, float] | None:
+    """Return cached coordinates if present and fresh, else ``None``."""
+    if max_age_seconds is not None and max_age_seconds <= 0:
+        return None
+    if not path.exists():
+        return None
+    try:
+        payload: Mapping[str, object] = json.loads(path.read_text(encoding="utf-8"))
+        fetched_at = datetime.fromisoformat(str(payload["fetched_at"]))
+        if fetched_at.tzinfo is None:
+            fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+        age = (datetime.now(tz=timezone.utc) - fetched_at).total_seconds()
+        if max_age_seconds is not None and age > max_age_seconds:
+            return None
+        return float(payload["latitude"]), float(payload["longitude"])  # pyright: ignore[reportArgumentType]
+    except (OSError, ValueError, KeyError, json.JSONDecodeError):
+        return None
+
+
+def _write_ipgeo_cache(path: Path, lat: float, lon: float) -> None:
+    payload = {
+        "latitude": lat,
+        "longitude": lon,
+        "fetched_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        # A cache write failure should never break the caller.
+        pass
+
+
+def _default_ipgeo_cache_path() -> Path:
+    """Cache file location for IP-geolocation results.
+
+    Co-located with the weather cache (one platform-specific dir for all
+    weather-related caches) to avoid scattering files across the filesystem.
+    """
+    # Imported lazily so this module stays importable when the index module
+    # is being constructed (avoids any chance of a cycle).
+    from .index import default_cache_dir
+
+    return default_cache_dir() / _IPGEO_CACHE_FILENAME
+
+
+def detect_location(
+    *,
+    cache_dir: Path | None = None,
+    max_age: timedelta | float | None = timedelta(hours=1),
+) -> tuple[float, float]:
+    """Detect approximate ``(latitude, longitude)`` from this machine's public IP.
+
+    Sends the machine's public IP to `ipapi.co <https://ipapi.co/>`_ over
+    HTTPS and parses the response. Accuracy is **city-level** — sufficient
+    for finding the nearest TMYx weather stations within a few tens of
+    kilometres, but not for precise positioning.
+
+    The result is cached to disk for ``max_age`` (default: 1 hour) so that
+    repeated invocations don't hammer the upstream service. Pass
+    ``max_age=None`` to cache indefinitely, or ``max_age=0`` to disable
+    caching entirely.
+
+    This function is thread-safe; concurrent calls are serialised by the
+    same rate limiter pattern used for Nominatim.
+
+    **Composable with spatial search:** Use the splat operator to combine
+    with [nearest][idfkit.weather.index.StationIndex.nearest] for
+    "weather stations near me" lookups:
+
+        ```python
+        from idfkit.weather import StationIndex, detect_location
+
+        results = StationIndex.load().nearest(*detect_location())
+        for r in results[:3]:
+            print(f"{r.station.display_name}: {r.distance_km:.0f} km")
+        ```
+
+    Args:
+        cache_dir: Directory for the cache file. Defaults to the platform
+            weather cache directory (same as :class:`WeatherDownloader`).
+        max_age: Maximum cache age before re-fetching. ``timedelta`` or
+            seconds; ``None`` means cache forever; ``0`` means always
+            re-fetch.
+
+    Returns:
+        A ``(latitude, longitude)`` tuple in decimal degrees.
+
+    Raises:
+        GeocodingError: If the IP cannot be located or the service is
+            unreachable.
+
+    Note:
+        Calling this function sends your public IP address to ipapi.co
+        over HTTPS. Use ``--lat`` / ``--lon`` (or ``--near ADDRESS``) on the
+        CLI if you'd rather not.
+    """
+    cache_path = (cache_dir / _IPGEO_CACHE_FILENAME) if cache_dir is not None else _default_ipgeo_cache_path()
+    age_limit = _max_age_seconds(max_age)
+
+    cached = _read_ipgeo_cache(cache_path, age_limit)
+    if cached is not None:
+        return cached
+
+    _ipapi_limiter.wait()
+
+    req = urllib.request.Request(_IPAPI_URL, headers={"User-Agent": _USER_AGENT})  # noqa: S310
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            data: Mapping[str, object] = json.loads(resp.read())
+        if data.get("error"):
+            reason = data.get("reason") or data.get("message") or "unknown error"
+            msg = f"ipapi.co could not locate this IP: {reason}"
+            raise GeocodingError(msg)
+        lat = data.get("latitude")
+        lon = data.get("longitude")
+        if lat is None or lon is None:
+            msg = "ipapi.co response missing latitude/longitude"
+            raise GeocodingError(msg)
+        coords = (float(lat), float(lon))  # pyright: ignore[reportArgumentType]
+    except (URLError, TimeoutError, json.JSONDecodeError, KeyError, ValueError, TypeError, AttributeError) as exc:
+        msg = f"Failed to detect location from IP: {exc}"
+        raise GeocodingError(msg) from exc
+
+    _write_ipgeo_cache(cache_path, *coords)
+    return coords

--- a/tests/test_weather_cli.py
+++ b/tests/test_weather_cli.py
@@ -138,6 +138,30 @@ class TestNamespaceToConfig:
         cfg = _namespace_to_config(ns)
         assert any("--max-km" in e for e in cfg.errors)
 
+    def test_nearby_alone_is_valid(self) -> None:
+        ns = _parse(["--nearby"])
+        cfg = _namespace_to_config(ns)
+        assert cfg.errors == ()
+        assert cfg.filters.nearby is True
+        assert cfg.filters.has_spatial
+        assert cfg.filters.has_any
+
+    def test_nearby_and_near_conflict(self) -> None:
+        ns = _parse(["--nearby", "--near", "Chicago"])
+        cfg = _namespace_to_config(ns)
+        assert any("--nearby cannot be combined with --near" in e for e in cfg.errors)
+
+    def test_nearby_and_lat_lon_conflict(self) -> None:
+        ns = _parse(["--nearby", "--lat", "40.7", "--lon", "-74.0"])
+        cfg = _namespace_to_config(ns)
+        assert any("--nearby cannot be combined with --lat/--lon" in e for e in cfg.errors)
+
+    def test_nearby_with_max_km_is_valid(self) -> None:
+        ns = _parse(["--nearby", "--max-km", "50"])
+        cfg = _namespace_to_config(ns)
+        assert cfg.errors == ()
+        assert cfg.filters.max_km == 50.0
+
     def test_full_filters(self) -> None:
         ns = _parse([
             "chicago",
@@ -380,6 +404,57 @@ class TestRunTmy:
             code = run_tmy(ns)
         assert code == EXIT_NETWORK
         assert "boom" in capsys.readouterr().err
+
+    def test_nearby_resolves_via_detect_location(
+        self,
+        sample_index: StationIndex,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--nearby", "--max-km", "100", "--json"])
+        with (
+            patch.object(StationIndex, "load", return_value=sample_index),
+            patch(
+                "idfkit.weather._cli.detect_location",
+                return_value=(41.9, -87.8),
+            ) as mock_detect,
+        ):
+            code = run_tmy(ns)
+        assert code == EXIT_OK
+        mock_detect.assert_called_once()
+        parsed = json.loads(capsys.readouterr().out)
+        # Sample index has two Chicago-area stations within 100 km of (41.9, -87.8)
+        assert len(parsed) >= 1
+        assert all(m["distance_km"] is not None for m in parsed)
+
+    def test_nearby_network_failure_returns_exit_3(
+        self,
+        sample_index: StationIndex,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from idfkit.weather.geocode import GeocodingError
+
+        ns = _parse(["--nearby"])
+        with (
+            patch.object(StationIndex, "load", return_value=sample_index),
+            patch(
+                "idfkit.weather._cli.detect_location",
+                side_effect=GeocodingError("offline"),
+            ),
+        ):
+            code = run_tmy(ns)
+        assert code == EXIT_NETWORK
+        err = capsys.readouterr().err
+        assert "geocoding failed" in err
+        assert "offline" in err
+
+    def test_nearby_with_near_errors(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ns = _parse(["--nearby", "--near", "Chicago"])
+        code = run_tmy(ns)
+        assert code == EXIT_USAGE
+        assert "--nearby cannot be combined with --near" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_weather_geocode.py
+++ b/tests/test_weather_geocode.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from idfkit.weather.geocode import GeocodingError, RateLimiter, _nominatim_limiter, geocode
+from idfkit.weather.geocode import (
+    GeocodingError,
+    RateLimiter,
+    _ipapi_limiter,  # pyright: ignore[reportPrivateUsage]
+    _nominatim_limiter,  # pyright: ignore[reportPrivateUsage]
+    detect_location,
+    geocode,
+)
 
 
 def _mock_response(data: bytes) -> MagicMock:
@@ -20,8 +29,9 @@ def _mock_response(data: bytes) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def reset_rate_limiter() -> None:
-    """Reset the global rate limiter before each test."""
+    """Reset the global rate limiters before each test."""
     _nominatim_limiter.reset()
+    _ipapi_limiter.reset()
 
 
 class TestRateLimiter:
@@ -118,3 +128,122 @@ class TestGeocode:
 
         with pytest.raises(GeocodingError, match="Failed to geocode"):
             geocode("Chicago, IL")
+
+
+class TestDetectLocation:
+    """Tests for detect_location() (mocked, no network)."""
+
+    @patch("urllib.request.urlopen")
+    def test_successful_detection(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        body = {"latitude": 41.85, "longitude": -87.65, "city": "Chicago"}
+        mock_urlopen.return_value = _mock_response(json.dumps(body).encode())
+
+        lat, lon = detect_location(cache_dir=tmp_path)
+
+        assert abs(lat - 41.85) < 1e-6
+        assert abs(lon - (-87.65)) < 1e-6
+        # Cache file written
+        cache_file = tmp_path / "ipgeo.json"
+        assert cache_file.exists()
+        cached = json.loads(cache_file.read_text())
+        assert cached["latitude"] == pytest.approx(41.85)
+        assert cached["longitude"] == pytest.approx(-87.65)
+
+    @patch("urllib.request.urlopen")
+    def test_network_failure_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("Network unreachable")
+
+        with pytest.raises(GeocodingError, match="Failed to detect location"):
+            detect_location(cache_dir=tmp_path)
+
+    @patch("urllib.request.urlopen")
+    def test_error_response_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        body = {"error": True, "reason": "RateLimited", "message": "slow down"}
+        mock_urlopen.return_value = _mock_response(json.dumps(body).encode())
+
+        with pytest.raises(GeocodingError, match=r"could not locate"):
+            detect_location(cache_dir=tmp_path)
+
+    @patch("urllib.request.urlopen")
+    def test_missing_lat_lon_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        body = {"city": "somewhere"}  # No latitude/longitude
+        mock_urlopen.return_value = _mock_response(json.dumps(body).encode())
+
+        with pytest.raises(GeocodingError, match="missing latitude/longitude"):
+            detect_location(cache_dir=tmp_path)
+
+    @patch("urllib.request.urlopen")
+    def test_invalid_json_raises(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        mock_urlopen.return_value = _mock_response(b"not valid json")
+
+        with pytest.raises(GeocodingError, match="Failed to detect location"):
+            detect_location(cache_dir=tmp_path)
+
+    @patch("urllib.request.urlopen")
+    def test_cache_hit_skips_network(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        # Pre-populate a fresh cache entry.
+        cache_file = tmp_path / "ipgeo.json"
+        cache_file.write_text(
+            json.dumps({
+                "latitude": 51.5,
+                "longitude": -0.12,
+                "fetched_at": datetime.now(tz=timezone.utc).isoformat(),
+            })
+        )
+        mock_urlopen.side_effect = AssertionError("network should not be called on cache hit")
+
+        lat, lon = detect_location(cache_dir=tmp_path, max_age=timedelta(hours=1))
+
+        assert abs(lat - 51.5) < 1e-6
+        assert abs(lon - (-0.12)) < 1e-6
+        mock_urlopen.assert_not_called()
+
+    @patch("urllib.request.urlopen")
+    def test_cache_stale_refetches(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        cache_file = tmp_path / "ipgeo.json"
+        # Write a 2-hour-old cache entry.
+        old = datetime.now(tz=timezone.utc) - timedelta(hours=2)
+        cache_file.write_text(json.dumps({"latitude": 0.0, "longitude": 0.0, "fetched_at": old.isoformat()}))
+        body = {"latitude": 41.85, "longitude": -87.65}
+        mock_urlopen.return_value = _mock_response(json.dumps(body).encode())
+
+        lat, lon = detect_location(cache_dir=tmp_path, max_age=timedelta(hours=1))
+
+        assert abs(lat - 41.85) < 1e-6
+        assert abs(lon - (-87.65)) < 1e-6
+        mock_urlopen.assert_called_once()
+
+    @patch("urllib.request.urlopen")
+    def test_max_age_zero_disables_cache(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        cache_file = tmp_path / "ipgeo.json"
+        # Even a brand-new cache should be ignored when max_age=0.
+        cache_file.write_text(
+            json.dumps({
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "fetched_at": datetime.now(tz=timezone.utc).isoformat(),
+            })
+        )
+        body = {"latitude": 12.34, "longitude": 56.78}
+        mock_urlopen.return_value = _mock_response(json.dumps(body).encode())
+
+        lat, lon = detect_location(cache_dir=tmp_path, max_age=0)
+
+        assert abs(lat - 12.34) < 1e-6
+        assert abs(lon - 56.78) < 1e-6
+        mock_urlopen.assert_called_once()
+
+    @patch("urllib.request.urlopen")
+    def test_corrupt_cache_falls_through(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        cache_file = tmp_path / "ipgeo.json"
+        cache_file.write_text("{not valid json")
+        body = {"latitude": 1.0, "longitude": 2.0}
+        mock_urlopen.return_value = _mock_response(json.dumps(body).encode())
+
+        lat, lon = detect_location(cache_dir=tmp_path)
+
+        assert abs(lat - 1.0) < 1e-6
+        assert abs(lon - 2.0) < 1e-6
+        mock_urlopen.assert_called_once()


### PR DESCRIPTION
Adds a `--nearby` flag that resolves the user's approximate coordinates
from their public IP address (via ipapi.co over HTTPS) and feeds them
into the existing TMYx spatial-search pipeline. Sits next to `--near`
(geocode an address) and `--lat/--lon` (explicit coordinates), and is
mutually exclusive with both.

Also adds a public `detect_location()` helper alongside `geocode()`,
with the same shape as the rest of the weather module. Results are
cached on disk for one hour by default (mirroring
`WeatherDownloader._is_stale()`) so repeated invocations don't hammer
the upstream service. The cache dir and TTL are configurable; the
fallback location is the existing platform weather cache.

The help text is explicit about the privacy footprint (IP leaves the
machine, sent to ipapi.co over HTTPS, cached locally). A code comment
documents the alternative providers evaluated so a future maintainer
can swap or add a fallback chain quickly.

Tests cover: success, network failure, error response, missing
lat/lon, invalid JSON, cache hit / stale / disabled / corrupt, plus
end-to-end CLI behaviour for `--nearby` alone, in conflict with
`--near` / `--lat`/`--lon`, and on geocoding failure (exits 3).