### PR TITLE
Add throttled freshness check for weather station index

### DIFF
--- a/src/idfkit/weather/index.py
+++ b/src/idfkit/weather/index.py
@@ -45,7 +45,7 @@ _CACHED_INDEX = "stations.json.gz"
 # Opt-out env var for the freshness nudge fired by `StationIndex.load()`.
 _DISABLE_UPDATE_CHECK_ENV_VAR = "IDFKIT_NO_WEATHER_UPDATE_CHECK"
 _UPDATE_CHECK_TIMESTAMP_FILE = "last_update_check"
-_UPDATE_CHECK_INTERVAL_SECONDS = 7 * 24 * 60 * 60
+_UPDATE_CHECK_INTERVAL_SECONDS = 24 * 60 * 60
 
 
 def default_cache_dir() -> Path:

--- a/src/idfkit/weather/index.py
+++ b/src/idfkit/weather/index.py
@@ -9,6 +9,7 @@ import math
 import os
 import re
 import sys
+import time
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +41,11 @@ _USER_AGENT = "idfkit (https://github.com/idfkit/idfkit)"
 
 _BUNDLED_INDEX = Path(__file__).parent / "data" / "stations.json.gz"
 _CACHED_INDEX = "stations.json.gz"
+
+# Opt-out env var for the freshness nudge fired by `StationIndex.load()`.
+_DISABLE_UPDATE_CHECK_ENV_VAR = "IDFKIT_NO_WEATHER_UPDATE_CHECK"
+_UPDATE_CHECK_TIMESTAMP_FILE = "last_update_check"
+_UPDATE_CHECK_INTERVAL_SECONDS = 7 * 24 * 60 * 60
 
 
 def default_cache_dir() -> Path:
@@ -411,6 +417,44 @@ def _score_station(station: WeatherStation, query: str, tokens: list[str]) -> tu
 # ---------------------------------------------------------------------------
 
 
+def _maybe_check_for_updates(index: StationIndex, cache_dir: Path) -> None:
+    """Throttled, best-effort freshness check for the weather (TMYx) station index.
+
+    Skipped silently when:
+    - ``IDFKIT_NO_WEATHER_UPDATE_CHECK`` is set in the environment
+    - A previous check ran less than ``_UPDATE_CHECK_INTERVAL_SECONDS`` ago
+    - The loaded index has no ``last_modified`` metadata to compare against
+    - The cache directory cannot be created or written to
+
+    Logs a warning when upstream KML data is newer than the loaded index.
+    Network errors are already swallowed by ``check_for_updates``.
+    """
+    if os.environ.get(_DISABLE_UPDATE_CHECK_ENV_VAR):
+        return
+    if not index._last_modified:  # pyright: ignore[reportPrivateUsage]
+        return
+
+    timestamp_path = cache_dir / _UPDATE_CHECK_TIMESTAMP_FILE
+    try:
+        if time.time() - timestamp_path.stat().st_mtime < _UPDATE_CHECK_INTERVAL_SECONDS:
+            return
+    except OSError:
+        pass
+
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        timestamp_path.touch()
+    except OSError:
+        return
+
+    if index.check_for_updates():
+        logger.warning(
+            "Weather (TMYx) station index from climate.onebuilding.org appears out of date. "
+            "Run StationIndex.refresh() to rebuild it. Set %s=1 to silence this check.",
+            _DISABLE_UPDATE_CHECK_ENV_VAR,
+        )
+
+
 class StationIndex:
     """Searchable index of weather stations from climate.onebuilding.org.
 
@@ -476,6 +520,7 @@ class StationIndex:
         logger.info("Loaded station index with %d stations from %s", len(stations), source)
         instance = cls(stations)
         instance._last_modified = last_modified
+        _maybe_check_for_updates(instance, cache)
         return instance
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,17 @@ class InMemoryAsyncFileSystem:
             del self._files[key]
 
 
+@pytest.fixture(autouse=True)
+def _disable_weather_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Suppress the weather index freshness nudge in `StationIndex.load()`.
+
+    Prevents tests that load the bundled index from making network calls or
+    emitting warnings. Tests that exercise the nudge explicitly delete the env
+    var via their own ``monkeypatch.delenv``.
+    """
+    monkeypatch.setenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", "1")
+
+
 @pytest.fixture
 def schema() -> EpJSONSchema:
     """Load the v24.1.0 schema."""

--- a/tests/test_weather_index.py
+++ b/tests/test_weather_index.py
@@ -1013,7 +1013,7 @@ class TestMaybeCheckForUpdates:
         monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
         stamp = tmp_path / "last_update_check"
         stamp.touch()
-        old = stamp.stat().st_mtime - (8 * 24 * 60 * 60)
+        old = stamp.stat().st_mtime - (2 * 24 * 60 * 60)
         os.utime(stamp, (old, old))
 
         with patch("idfkit.weather.index._head_last_modified", return_value=None) as head:

--- a/tests/test_weather_index.py
+++ b/tests/test_weather_index.py
@@ -917,6 +917,140 @@ class TestCheckForUpdates:
         assert idx.check_for_updates() is False
 
 
+class TestMaybeCheckForUpdates:
+    """Tests for the throttled freshness nudge in `StationIndex.load()`."""
+
+    @staticmethod
+    def _build_cache(tmp_path: Path, last_modified: dict[str, str] | None = None) -> Path:
+        stations = _fixture_stations()[:1]
+        lm = (
+            last_modified
+            if last_modified is not None
+            else {"Region1_Africa_TMYx_EPW_Processing_locations.kml": "Wed, 01 Jan 2020 00:00:00 GMT"}
+        )
+        dest = tmp_path / "stations.json.gz"
+        _save_compressed_index(stations, lm, dest)
+        return dest
+
+    def test_env_var_silences_check(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        self._build_cache(tmp_path)
+        monkeypatch.setenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", "1")
+
+        with (
+            patch("idfkit.weather.index._head_last_modified") as head,
+            caplog.at_level("WARNING", logger="idfkit.weather.index"),
+        ):
+            StationIndex.load(cache_dir=tmp_path)
+            head.assert_not_called()
+        assert not (tmp_path / "last_update_check").exists()
+        assert "out of date" not in caplog.text
+
+    def test_logs_warning_when_stale(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        self._build_cache(tmp_path)
+        monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
+
+        with (
+            patch(
+                "idfkit.weather.index._head_last_modified",
+                return_value="Wed, 15 Jan 2026 10:30:00 GMT",
+            ),
+            caplog.at_level("WARNING", logger="idfkit.weather.index"),
+        ):
+            StationIndex.load(cache_dir=tmp_path)
+
+        assert "out of date" in caplog.text
+        assert "IDFKIT_NO_WEATHER_UPDATE_CHECK" in caplog.text
+        assert (tmp_path / "last_update_check").exists()
+
+    def test_no_log_when_fresh(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        same = "Wed, 01 Jan 2020 00:00:00 GMT"
+        self._build_cache(tmp_path, last_modified={"Region1_Africa_TMYx_EPW_Processing_locations.kml": same})
+        monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
+
+        with (
+            patch("idfkit.weather.index._head_last_modified", return_value=same),
+            caplog.at_level("WARNING", logger="idfkit.weather.index"),
+        ):
+            StationIndex.load(cache_dir=tmp_path)
+
+        assert "out of date" not in caplog.text
+        assert (tmp_path / "last_update_check").exists()
+
+    def test_throttle_skips_within_window(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._build_cache(tmp_path)
+        monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
+        (tmp_path / "last_update_check").touch()
+
+        with patch("idfkit.weather.index._head_last_modified") as head:
+            StationIndex.load(cache_dir=tmp_path)
+            head.assert_not_called()
+
+    def test_throttle_runs_when_window_elapsed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._build_cache(tmp_path)
+        monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
+        stamp = tmp_path / "last_update_check"
+        stamp.touch()
+        old = stamp.stat().st_mtime - (8 * 24 * 60 * 60)
+        os.utime(stamp, (old, old))
+
+        with patch("idfkit.weather.index._head_last_modified", return_value=None) as head:
+            StationIndex.load(cache_dir=tmp_path)
+            head.assert_called()
+
+        assert stamp.stat().st_mtime > old
+
+    def test_skipped_when_no_last_modified(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._build_cache(tmp_path, last_modified={})
+        monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
+
+        with patch("idfkit.weather.index._head_last_modified") as head:
+            StationIndex.load(cache_dir=tmp_path)
+            head.assert_not_called()
+        assert not (tmp_path / "last_update_check").exists()
+
+    def test_unwritable_cache_dir_silently_skipped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._build_cache(tmp_path)
+        monkeypatch.delenv("IDFKIT_NO_WEATHER_UPDATE_CHECK", raising=False)
+
+        with (
+            patch("pathlib.Path.mkdir", side_effect=OSError("read-only")),
+            patch("idfkit.weather.index._head_last_modified") as head,
+        ):
+            StationIndex.load(cache_dir=tmp_path)
+            head.assert_not_called()
+
+
 class TestRefresh:
     def test_refresh_saves_and_loads(self, tmp_path: Path) -> None:
         stations = _fixture_stations()


### PR DESCRIPTION
## Summary
Adds a throttled, best-effort freshness check for the weather (TMYx) station index that runs when `StationIndex.load()` is called. The check compares the loaded index's metadata against upstream KML data and logs a warning if the index appears out of date.

## Key Changes
- **New `_maybe_check_for_updates()` function** in `src/idfkit/weather/index.py`:
  - Performs throttled freshness checks with a 24-hour interval between checks
  - Respects `IDFKIT_NO_WEATHER_UPDATE_CHECK` environment variable to opt out
  - Silently skips when index lacks `last_modified` metadata or cache directory is unwritable
  - Logs a warning when upstream data is newer than the cached index
  - Uses a `last_update_check` timestamp file to track check frequency

- **Integration with `StationIndex.load()`**:
  - Calls `_maybe_check_for_updates()` after loading the index
  - Passes the cache directory and loaded index instance to the check function

- **Test suite** (`tests/test_weather_index.py`):
  - New `TestMaybeCheckForUpdates` class with 7 comprehensive test cases covering:
    - Environment variable opt-out behavior
    - Warning logging when index is stale
    - No warning when index is fresh
    - Throttling within the check window
    - Throttling expiration after 24+ hours
    - Graceful skipping when metadata is missing
    - Silent handling of unwritable cache directories

- **Test fixture** (`tests/conftest.py`):
  - Auto-use fixture that disables the update check by default to prevent network calls and warnings in unrelated tests
  - Individual tests explicitly opt in by removing the environment variable

## Implementation Details
- Uses `time.time()` and file modification times for throttling logic
- Network errors from `check_for_updates()` are already handled gracefully
- All OSError exceptions (permission denied, missing directories, etc.) are caught and silently ignored
- The timestamp file is only created/touched after passing all precondition checks

https://claude.ai/code/session_01XnL1F67SwkU87rwPr38R1y