### PR TITLE
Document environment variables consulted by idfkit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,28 @@ make check && make test
 
 This runs: lock file validation, pre-commit hooks (ruff format + lint, JSON formatting, trailing whitespace), pyright, deptry (unused dependency detection), and pytest with coverage.
 
+## Environment Variables
+
+The complete list of environment variables idfkit reads is documented in
+[`docs/concepts/environment-variables.md`](docs/concepts/environment-variables.md).
+
+**IMPORTANT:** Whenever you add, rename, or remove a call to `os.environ`,
+`os.getenv`, or any other env-var lookup in `src/idfkit/` (or change a
+default, opt-out flag, or platform behaviour for one), you MUST update
+`docs/concepts/environment-variables.md` in the same change so the docs stay
+in sync with the code. This applies to user-facing variables (e.g.
+`ENERGYPLUS_DIR`, `IDFKIT_NO_WEATHER_UPDATE_CHECK`) and to standard platform
+variables that idfkit consults (e.g. `XDG_CACHE_HOME`, `LOCALAPPDATA`,
+`ProgramFiles*`, `SYSTEMDRIVE`).
+
+Quick audit command:
+
+```bash
+grep -rn "os.environ\|os.getenv" src/idfkit/
+```
+
+Every variable that command surfaces should appear in the docs page.
+
 ## EnergyPlus Version Support
 
 Bundled schemas cover EnergyPlus 8.9.0 through 26.1.0 (17 versions). The latest supported version is 26.1.0. Version 24.1.0 is used as the default in test fixtures. See `src/idfkit/versions.py` for the full list.

--- a/docs/concepts/environment-variables.md
+++ b/docs/concepts/environment-variables.md
@@ -1,0 +1,99 @@
+# Environment Variables
+
+idfkit reads a small number of environment variables to control EnergyPlus
+discovery, cache locations, and a few opt-out flags. This page lists every
+variable the package consults, where it is read, and the default behaviour
+when the variable is not set.
+
+## idfkit-Specific Variables
+
+### `ENERGYPLUS_DIR`
+
+Path to an EnergyPlus installation directory. Used by
+[`find_energyplus()`](../api/simulation/runner.md) and the simulation runner
+to locate the `energyplus` executable.
+
+- **Read in:** `idfkit.simulation.config`
+- **Default:** unset — discovery falls back to (in order) the `path` argument
+  passed to `find_energyplus()`, the system `PATH`, then platform-specific
+  default install locations.
+- **Example:**
+
+    ```bash
+    export ENERGYPLUS_DIR=/usr/local/EnergyPlus-24-2-0
+    ```
+
+See [Installation › EnergyPlus Installation](../getting-started/installation.md#energyplus-installation)
+for the full discovery order.
+
+### `IDFKIT_NO_WEATHER_UPDATE_CHECK`
+
+Opt-out flag that suppresses the once-per-day freshness nudge emitted when
+`StationIndex.load()` notices the bundled station index may be stale.
+
+- **Read in:** `idfkit.weather.index`
+- **Default:** unset — the freshness nudge is enabled.
+- **Activation:** set to any non-empty value to disable the check.
+- **Example:**
+
+    ```bash
+    export IDFKIT_NO_WEATHER_UPDATE_CHECK=1
+    ```
+
+## Standard Platform Variables
+
+idfkit honours standard OS-level variables when computing default cache
+directories and discovering EnergyPlus on Windows. You generally do not need
+to set these yourself — they exist on every supported platform — but
+overriding them changes where idfkit reads and writes cached data.
+
+### `XDG_CACHE_HOME` (Linux / POSIX)
+
+Base directory for user cache data, per the
+[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+
+- **Read in:** `idfkit.simulation.cache`, `idfkit.weather.index`
+- **Default:** `~/.cache`
+- **Effect:** Simulation cache lives at `$XDG_CACHE_HOME/idfkit/cache/simulations`;
+  weather cache lives at `$XDG_CACHE_HOME/idfkit/weather`.
+
+### `LOCALAPPDATA` (Windows)
+
+Standard Windows variable pointing to the per-user local application data
+directory.
+
+- **Read in:** `idfkit.simulation.cache`, `idfkit.weather.index`
+- **Default:** `%UserProfile%\AppData\Local`
+- **Effect:** Simulation and weather caches live under
+  `%LOCALAPPDATA%\idfkit\cache\`.
+
+### `ProgramFiles`, `ProgramFiles(x86)`, `ProgramW6432` (Windows)
+
+Standard Windows variables used to locate EnergyPlus installations under
+`Program Files` directories during discovery.
+
+- **Read in:** `idfkit.simulation.config`
+- **Default:** if unset, those candidate locations are skipped.
+
+### `SYSTEMDRIVE` (Windows)
+
+Standard Windows variable identifying the drive that hosts the OS, used as a
+fallback root when scanning for `EnergyPlusV*` installs at the drive root.
+
+- **Read in:** `idfkit.simulation.config`
+- **Default:** `C:`
+
+## Quick Reference
+
+| Variable                          | Purpose                                | Default                              |
+|-----------------------------------|----------------------------------------|--------------------------------------|
+| `ENERGYPLUS_DIR`                  | EnergyPlus install path                | unset (PATH + platform defaults)     |
+| `IDFKIT_NO_WEATHER_UPDATE_CHECK`  | Disable weather index freshness nudge  | unset (check enabled)                |
+| `XDG_CACHE_HOME`                  | Linux cache root                       | `~/.cache`                           |
+| `LOCALAPPDATA`                    | Windows cache root                     | `%UserProfile%\AppData\Local`        |
+| `ProgramFiles` / `ProgramFiles(x86)` / `ProgramW6432` | Windows EnergyPlus discovery | unset locations skipped     |
+| `SYSTEMDRIVE`                     | Windows EnergyPlus discovery fallback  | `C:`                                 |
+
+!!! note "macOS"
+    On macOS, idfkit does not consult an environment variable for cache
+    locations — caches live under `~/Library/Caches/idfkit/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
     - Simulation Architecture: concepts/simulation-architecture.md
     - Weather Data Pipeline: concepts/weather-pipeline.md
     - Caching Strategy: concepts/caching.md
+    - Environment Variables: concepts/environment-variables.md
     - Logging: concepts/logging.md
     - Cloud & Remote Storage: concepts/cloud-storage.md
     - Type-Safe Development: concepts/type-safety.md


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for all environment variables that idfkit reads, including user-facing variables, standard platform variables, and their default behaviors. It also establishes a requirement that environment variable changes must be kept in sync with the documentation.

## Changes

- **New documentation page** (`docs/concepts/environment-variables.md`):
  - Documents `ENERGYPLUS_DIR` for EnergyPlus discovery
  - Documents `IDFKIT_NO_WEATHER_UPDATE_CHECK` opt-out flag
  - Documents standard platform variables: `XDG_CACHE_HOME`, `LOCALAPPDATA`, `ProgramFiles*`, `SYSTEMDRIVE`
  - Includes default behaviors, read locations, and examples for each variable
  - Provides a quick reference table and platform-specific notes

- **Updated developer guide** (`CLAUDE.md`):
  - Added "Environment Variables" section with requirements for keeping docs in sync
  - Includes audit command (`grep -rn "os.environ\|os.getenv" src/idfkit/`) to verify completeness
  - Clarifies that all env-var lookups must be documented

- **Updated site navigation** (`mkdocs.yml`):
  - Added "Environment Variables" page to the Concepts section

## Implementation Details

The documentation is organized into three sections:
1. **idfkit-Specific Variables** — user-facing configuration options
2. **Standard Platform Variables** — OS-level variables idfkit honors
3. **Quick Reference** — summary table for easy lookup

Each variable entry includes the module where it's read, default behavior, activation instructions (for opt-out flags), and examples.

https://claude.ai/code/session_011rR4jpPrsxcutD2NJKypqY