### PR TITLE
fix(introspection): preserve anyOf union in FieldDescription.field_type

### DIFF
--- a/src/idfkit/introspection.py
+++ b/src/idfkit/introspection.py
@@ -22,7 +22,11 @@ class FieldDescription:
 
     Attributes:
         name: Field name (python-style, e.g., "x_origin")
-        field_type: Type of the field ("number", "string", "integer", etc.)
+        field_type: Type of the field ("number", "string", "integer", etc.). For
+            heterogeneous fields declared via ``anyOf`` with multiple primitive
+            types (e.g. ``Schedule:Compact``'s ``field``, which mixes directives
+            like ``Through: 12/31`` with numeric values), this is a pipe-delimited
+            union in declaration order — e.g. ``"number|string"``.
         required: Whether the field is required
         default: Default value, if any
         units: Units string, if any (e.g., "m", "W/m-K")
@@ -282,21 +286,28 @@ def describe_object_type(schema: EpJSONSchema, obj_type: str) -> ObjectDescripti
 
 
 def _get_field_type(field_schema: dict[str, Any]) -> str | None:
-    """Extract the field type from a field schema."""
+    """Extract the field type from a field schema.
+
+    For ``anyOf`` schemas declaring multiple primitive types (e.g.
+    ``Schedule:Compact``'s extensible ``field`` allows both number and string),
+    returns a pipe-delimited union in declaration order — e.g. ``"number|string"``
+    — so callers can see the field is heterogeneous instead of being told only
+    the preferred type. Sub-schemas without a ``type`` key (pure ``enum``
+    branches) are ignored, matching the prior contract.
+    """
     if "type" in field_schema:
         result: str = field_schema["type"]
         return result
 
     if "anyOf" in field_schema:
         any_of: list[dict[str, Any]] = field_schema["anyOf"]
-        # Look for a primary type (prefer number/integer over string)
+        types: list[str] = []
         for sub in any_of:
-            if sub.get("type") in ("number", "integer"):
-                result = sub["type"]
-                return result
-        for sub in any_of:
-            if sub.get("type") == "string":
-                return "string"
+            sub_type = sub.get("type")
+            if isinstance(sub_type, str) and sub_type not in types:
+                types.append(sub_type)
+        if types:
+            return "|".join(types)
 
     if "enum" in field_schema:
         return "string"

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -221,6 +221,21 @@ class TestDescribeObjectType:
         vertex_fields = [f for f in desc2.fields if f.name.startswith("vertex_")]
         assert all(f.field_type == "number" for f in vertex_fields)
 
+    def test_schedule_compact_field_is_heterogeneous(self, schema: EpJSONSchema) -> None:
+        """Schedule:Compact's extensible 'field' allows both numbers and strings.
+
+        EnergyPlus declares it as ``anyOf: [number, string]`` because rows interleave
+        directives like ``Through: 12/31`` with numeric values. The describe path must
+        surface both types so callers know strings are valid (regression for the
+        upstream issue raised against idfkit-mcp).
+        """
+        desc = describe_object_type(schema, "Schedule:Compact")
+        field = next((f for f in desc.fields if f.name == "field"), None)
+        assert field is not None
+        assert field.field_type is not None
+        assert "number" in field.field_type
+        assert "string" in field.field_type
+
     def test_nameless_object(self, schema: EpJSONSchema) -> None:
         desc = describe_object_type(schema, "Timestep")
         assert desc.has_name is False
@@ -240,17 +255,28 @@ class TestGetFieldType:
         result = _get_field_type({"type": "number"})
         assert result == "number"
 
-    def test_anyof_prefers_number(self) -> None:
+    def test_anyof_returns_union_in_declaration_order(self) -> None:
         field_schema: dict[str, object] = {"anyOf": [{"type": "string"}, {"type": "number"}]}
         result = _get_field_type(field_schema)
-        assert result == "number"
+        assert result == "string|number"
 
-    def test_anyof_prefers_integer(self) -> None:
+    def test_anyof_number_first_keeps_number_first(self) -> None:
+        field_schema: dict[str, object] = {"anyOf": [{"type": "number"}, {"type": "string"}]}
+        result = _get_field_type(field_schema)
+        assert result == "number|string"
+
+    def test_anyof_integer_and_string_returns_union(self) -> None:
         field_schema: dict[str, object] = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
         result = _get_field_type(field_schema)
-        assert result == "integer"
+        assert result == "string|integer"
 
-    def test_anyof_falls_back_to_string(self) -> None:
+    def test_anyof_dedupes_repeated_types(self) -> None:
+        field_schema: dict[str, object] = {"anyOf": [{"type": "number"}, {"type": "number"}, {"type": "string"}]}
+        result = _get_field_type(field_schema)
+        assert result == "number|string"
+
+    def test_anyof_ignores_subschemas_without_type(self) -> None:
+        """Sub-schemas with only 'enum' (no 'type') don't contribute to the union."""
         field_schema: dict[str, object] = {"anyOf": [{"type": "string"}, {"enum": ["A", "B"]}]}
         result = _get_field_type(field_schema)
         assert result == "string"


### PR DESCRIPTION
## Summary

- `_get_field_type` (in `src/idfkit/introspection.py`) collapsed `anyOf` schemas with multiple primitive types to a single preferred type (number > integer > string), hiding heterogeneity in the describe output.
- Concrete impact: `Schedule:Compact`'s extensible `field` is declared `anyOf: [number, string]` in the bundled epJSON schema because rows interleave directives like `Through: 12/31` with numeric values, but `describe_object_type` reported `field_type="number"` — misleading any caller (humans, LLMs via idfkit-mcp, language servers) trying to author a valid object.
- Now: return the full primitive type set as a pipe-delimited union in declaration order (e.g. `"number|string"`). Single-type fields, enum-only `anyOf` sub-schemas, and bare `enum`/empty schemas keep their existing behavior.

## Scope

The hot path is intentionally untouched:
- `schema._resolve_field_type` (used by `idf_parser._coerce_value_fast` and `schema.get_field_type`)
- `codegen._schema_field_type` in `generate_stubs.py`

These continue to return a single type string, so IDF parsing, codegen, and validation are unaffected. The change is contained to `FieldDescription.field_type`, whose consumers (idfkit-mcp serializer, idfkit-lsp display strings, idfkit-docs `schema_utils`) all pass the value through as a string.

## Test plan

- [x] `make check` passes (ruff, pyright, deptry; the one preexisting pyright warning about `_generated_types` is unrelated)
- [x] `make test` — all 3132 tests pass, including new regression coverage:
  - `test_schedule_compact_field_is_heterogeneous` — exercises the real bundled schema
  - `test_anyof_returns_union_in_declaration_order`, `test_anyof_number_first_keeps_number_first`, `test_anyof_integer_and_string_returns_union`, `test_anyof_dedupes_repeated_types`, `test_anyof_ignores_subschemas_without_type`
- [x] Existing assertions (e.g. vertex fields are pure `number`) still hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)