### PR TITLE
feat(weather): selective ZIP extraction via download(only=...)

### DIFF
--- a/src/idfkit/weather/__init__.py
+++ b/src/idfkit/weather/__init__.py
@@ -96,7 +96,7 @@ from __future__ import annotations
 
 from ..exceptions import NoDesignDaysError
 from .designday import DesignDayManager, DesignDayType, apply_ashrae_sizing
-from .download import WeatherDownloader, WeatherFiles
+from .download import PartialWeatherFiles, WeatherDownloader, WeatherFiles
 from .geocode import GeocodingError, detect_location, geocode
 from .index import StationIndex
 from .station import SearchResult, SpatialResult, WeatherStation
@@ -106,6 +106,7 @@ __all__ = [
     "DesignDayType",
     "GeocodingError",
     "NoDesignDaysError",
+    "PartialWeatherFiles",
     "SearchResult",
     "SpatialResult",
     "StationIndex",

--- a/src/idfkit/weather/download.py
+++ b/src/idfkit/weather/download.py
@@ -9,7 +9,7 @@ import zipfile
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -41,17 +41,39 @@ def _normalise_suffixes(suffixes: Iterable[str] | None) -> frozenset[str] | None
 
 @dataclass(frozen=True)
 class WeatherFiles:
-    """Paths to downloaded and extracted weather files.
+    """Paths to a fully extracted weather bundle.
 
-    For a full extraction (``download(station)`` without ``only``), ``epw`` and
-    ``ddy`` are guaranteed non-``None`` — a missing one raises during download.
-    When a selective extraction is requested via ``only=``, any field whose
-    suffix was not requested *and* not already cached on disk will be ``None``.
+    Returned by ``WeatherDownloader.download(station)`` (no ``only=``).
+    ``epw`` and ``ddy`` are guaranteed non-``None`` — a missing one raises
+    during download.
+
+    Attributes:
+        epw: Path to the ``.epw`` file.
+        ddy: Path to the ``.ddy`` file.
+        stat: Path to the ``.stat`` file, or ``None`` if not included.
+        zip_path: Path to the original downloaded ZIP archive.
+        station: The station this download corresponds to.
+    """
+
+    epw: Path
+    ddy: Path
+    stat: Path | None
+    zip_path: Path
+    station: WeatherStation
+
+
+@dataclass(frozen=True)
+class PartialWeatherFiles:
+    """Paths to a selectively extracted weather bundle.
+
+    Returned by ``WeatherDownloader.download(station, only=...)``. Any field
+    whose suffix was not requested *and* not already cached on disk will be
+    ``None``.
 
     Attributes:
         epw: Path to the ``.epw`` file, or ``None`` if not extracted.
         ddy: Path to the ``.ddy`` file, or ``None`` if not extracted.
-        stat: Path to the ``.stat`` file, or ``None`` if not included or extracted.
+        stat: Path to the ``.stat`` file, or ``None`` if not extracted.
         zip_path: Path to the original downloaded ZIP archive.
         station: The station this download corresponds to.
     """
@@ -116,12 +138,18 @@ class WeatherDownloader:
         age = time.time() - path.stat().st_mtime
         return age > self._max_age_seconds
 
+    @overload
+    def download(self, station: WeatherStation) -> WeatherFiles: ...
+    @overload
+    def download(self, station: WeatherStation, *, only: None) -> WeatherFiles: ...
+    @overload
+    def download(self, station: WeatherStation, *, only: Iterable[str]) -> PartialWeatherFiles: ...
     def download(
         self,
         station: WeatherStation,
         *,
         only: Iterable[str] | None = None,
-    ) -> WeatherFiles:
+    ) -> WeatherFiles | PartialWeatherFiles:
         """Download and extract weather files for *station*.
 
         If the files are already cached and not stale, no network request is made.
@@ -137,7 +165,10 @@ class WeatherDownloader:
                 and a ``.ddy``.
 
         Returns:
-            A [WeatherFiles][idfkit.weather.download.WeatherFiles] with paths to the extracted files.
+            [WeatherFiles][idfkit.weather.download.WeatherFiles] for a full
+            extraction, or
+            [PartialWeatherFiles][idfkit.weather.download.PartialWeatherFiles]
+            when ``only=`` is set.
 
         Raises:
             RuntimeError: If the download or extraction fails, or if a full
@@ -170,15 +201,22 @@ class WeatherDownloader:
         ddy_path = self._find_file(station_dir, ".ddy")
         stat_path = self._find_file(station_dir, ".stat")
 
-        # When the caller asked for a full extraction, EPW and DDY are required.
-        if only_set is None:
-            if epw_path is None:
-                msg = f"No .epw file found in downloaded archive for {station.display_name}"
-                raise RuntimeError(msg)
-            if ddy_path is None:
-                msg = f"No .ddy file found in downloaded archive for {station.display_name}"
-                raise RuntimeError(msg)
+        if only_set is not None:
+            return PartialWeatherFiles(
+                epw=epw_path,
+                ddy=ddy_path,
+                stat=stat_path,
+                zip_path=zip_path,
+                station=station,
+            )
 
+        # Full-extract path: EPW and DDY are required.
+        if epw_path is None:
+            msg = f"No .epw file found in downloaded archive for {station.display_name}"
+            raise RuntimeError(msg)
+        if ddy_path is None:
+            msg = f"No .ddy file found in downloaded archive for {station.display_name}"
+            raise RuntimeError(msg)
         return WeatherFiles(
             epw=epw_path,
             ddy=ddy_path,
@@ -224,9 +262,7 @@ class WeatherDownloader:
         Extracts the full archive. To skip extraction of unwanted members,
         call ``download(station, only={".epw"}).epw`` directly.
         """
-        epw = self.download(station).epw
-        assert epw is not None  # noqa: S101 — guaranteed by full-extract validation
-        return epw
+        return self.download(station).epw
 
     def get_ddy(self, station: WeatherStation) -> Path:
         """Download and return the path to the DDY file.
@@ -234,9 +270,7 @@ class WeatherDownloader:
         Extracts the full archive. To skip extraction of unwanted members,
         call ``download(station, only={".ddy"}).ddy`` directly.
         """
-        ddy = self.download(station).ddy
-        assert ddy is not None  # noqa: S101 — guaranteed by full-extract validation
-        return ddy
+        return self.download(station).ddy
 
     def _resolve_filename(self, filename: str, index: StationIndex | None) -> WeatherStation:
         """Resolve an EPW filename to a station, raising on failure."""

--- a/src/idfkit/weather/download.py
+++ b/src/idfkit/weather/download.py
@@ -17,6 +17,8 @@ from .index import default_cache_dir
 from .station import WeatherStation
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .index import StationIndex
 
 logger = logging.getLogger(__name__)
@@ -24,20 +26,38 @@ logger = logging.getLogger(__name__)
 _USER_AGENT = "idfkit (https://github.com/idfkit/idfkit)"
 
 
+def _normalise_suffixes(suffixes: Iterable[str] | None) -> frozenset[str] | None:
+    """Normalise a user-supplied collection of suffixes to lowercased ``.ext`` form."""
+    if suffixes is None:
+        return None
+    out: set[str] = set()
+    for s in suffixes:
+        token = s.lower()
+        if not token.startswith("."):
+            token = f".{token}"
+        out.add(token)
+    return frozenset(out)
+
+
 @dataclass(frozen=True)
 class WeatherFiles:
     """Paths to downloaded and extracted weather files.
 
+    For a full extraction (``download(station)`` without ``only``), ``epw`` and
+    ``ddy`` are guaranteed non-``None`` — a missing one raises during download.
+    When a selective extraction is requested via ``only=``, any field whose
+    suffix was not requested *and* not already cached on disk will be ``None``.
+
     Attributes:
-        epw: Path to the ``.epw`` file (always present after extraction).
-        ddy: Path to the ``.ddy`` file (always present after extraction).
-        stat: Path to the ``.stat`` file, or ``None`` if not included.
+        epw: Path to the ``.epw`` file, or ``None`` if not extracted.
+        ddy: Path to the ``.ddy`` file, or ``None`` if not extracted.
+        stat: Path to the ``.stat`` file, or ``None`` if not included or extracted.
         zip_path: Path to the original downloaded ZIP archive.
         station: The station this download corresponds to.
     """
 
-    epw: Path
-    ddy: Path
+    epw: Path | None
+    ddy: Path | None
     stat: Path | None
     zip_path: Path
     station: WeatherStation
@@ -96,19 +116,32 @@ class WeatherDownloader:
         age = time.time() - path.stat().st_mtime
         return age > self._max_age_seconds
 
-    def download(self, station: WeatherStation) -> WeatherFiles:
+    def download(
+        self,
+        station: WeatherStation,
+        *,
+        only: Iterable[str] | None = None,
+    ) -> WeatherFiles:
         """Download and extract weather files for *station*.
 
         If the files are already cached and not stale, no network request is made.
 
         Args:
             station: The weather station to download files for.
+            only: If given, extract only members whose suffix matches one of
+                these values (e.g. ``{".epw"}`` or ``[".epw", ".ddy"]``).
+                Each entry is normalised to a lowercase suffix with a leading
+                dot (``"epw"`` and ``".EPW"`` both match ``.epw`` members).
+                When ``None`` (default), every member of the archive is
+                extracted and the result is required to contain a ``.epw``
+                and a ``.ddy``.
 
         Returns:
             A [WeatherFiles][idfkit.weather.download.WeatherFiles] with paths to the extracted files.
 
         Raises:
-            RuntimeError: If the download or extraction fails.
+            RuntimeError: If the download or extraction fails, or if a full
+                extraction is missing a required ``.epw`` or ``.ddy`` file.
         """
         # Derive a cache subdirectory from the ZIP filename
         zip_filename = station.url.rsplit("/", maxsplit=1)[-1]
@@ -130,33 +163,21 @@ class WeatherDownloader:
         else:
             logger.debug("Cache hit for station %s (WMO %s)", station.display_name, station.wmo)
 
-        # Extract if EPW doesn't already exist or if the ZIP is newer than
-        # the EPW (i.e. we just re-downloaded).  We compare against the ZIP's
-        # mtime rather than calling ``_is_stale(epw_path)`` because
-        # ``zipfile.extractall`` preserves archive-internal timestamps, so the
-        # extracted EPW's mtime can be arbitrarily old and would always appear
-        # stale.
+        only_set = _normalise_suffixes(only)
+        self._ensure_extracted(zip_path, station_dir, only_set)
+
         epw_path = self._find_file(station_dir, ".epw")
-        needs_extract = epw_path is None or (zip_path.exists() and epw_path.stat().st_mtime < zip_path.stat().st_mtime)
-        if needs_extract:
-            try:
-                with zipfile.ZipFile(zip_path) as zf:
-                    zf.extractall(station_dir)
-            except zipfile.BadZipFile as exc:
-                msg = f"Downloaded file is not a valid ZIP archive: {zip_path}"
-                raise RuntimeError(msg) from exc
-            epw_path = self._find_file(station_dir, ".epw")
-
-        if epw_path is None:
-            msg = f"No .epw file found in downloaded archive for {station.display_name}"
-            raise RuntimeError(msg)
-
         ddy_path = self._find_file(station_dir, ".ddy")
-        if ddy_path is None:
-            msg = f"No .ddy file found in downloaded archive for {station.display_name}"
-            raise RuntimeError(msg)
-
         stat_path = self._find_file(station_dir, ".stat")
+
+        # When the caller asked for a full extraction, EPW and DDY are required.
+        if only_set is None:
+            if epw_path is None:
+                msg = f"No .epw file found in downloaded archive for {station.display_name}"
+                raise RuntimeError(msg)
+            if ddy_path is None:
+                msg = f"No .ddy file found in downloaded archive for {station.display_name}"
+                raise RuntimeError(msg)
 
         return WeatherFiles(
             epw=epw_path,
@@ -166,13 +187,56 @@ class WeatherDownloader:
             station=station,
         )
 
+    @staticmethod
+    def _ensure_extracted(
+        zip_path: Path,
+        station_dir: Path,
+        only: frozenset[str] | None,
+    ) -> None:
+        """Extract members from *zip_path* into *station_dir*.
+
+        If *only* is ``None``, every member is extracted (matching the
+        historical ``extractall`` behaviour). Otherwise, only members whose
+        lowercased suffix is in *only* are extracted. A member is skipped if
+        an up-to-date copy already exists on disk (mtime ≥ ZIP mtime).
+        """
+        try:
+            with zipfile.ZipFile(zip_path) as zf:
+                # Compare against the ZIP's mtime rather than ``_is_stale`` —
+                # ``zipfile`` preserves archive-internal timestamps, so the
+                # extracted file's mtime can be arbitrarily old.
+                zip_mtime = zip_path.stat().st_mtime
+                for member in zf.namelist():
+                    suffix = Path(member).suffix.lower()
+                    if only is not None and suffix not in only:
+                        continue
+                    target = station_dir / Path(member).name
+                    if target.exists() and target.stat().st_mtime >= zip_mtime:
+                        continue
+                    zf.extract(member, station_dir)
+        except zipfile.BadZipFile as exc:
+            msg = f"Downloaded file is not a valid ZIP archive: {zip_path}"
+            raise RuntimeError(msg) from exc
+
     def get_epw(self, station: WeatherStation) -> Path:
-        """Download and return the path to the EPW file."""
-        return self.download(station).epw
+        """Download and return the path to the EPW file.
+
+        Extracts the full archive. To skip extraction of unwanted members,
+        call ``download(station, only={".epw"}).epw`` directly.
+        """
+        epw = self.download(station).epw
+        assert epw is not None  # noqa: S101 — guaranteed by full-extract validation
+        return epw
 
     def get_ddy(self, station: WeatherStation) -> Path:
-        """Download and return the path to the DDY file."""
-        return self.download(station).ddy
+        """Download and return the path to the DDY file.
+
+        Extracts the full archive. To skip extraction of unwanted members,
+        call ``download(station, only={".ddy"}).ddy`` directly.
+        """
+        ddy = self.download(station).ddy
+        assert ddy is not None  # noqa: S101 — guaranteed by full-extract validation
+        return ddy
 
     def _resolve_filename(self, filename: str, index: StationIndex | None) -> WeatherStation:
         """Resolve an EPW filename to a station, raising on failure."""

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -79,8 +79,8 @@ class TestWeatherDownloader:
         station = _make_station()
         files = downloader.download(station)
 
-        assert files.epw is not None and files.epw.exists()
-        assert files.ddy is not None and files.ddy.exists()
+        assert files.epw.exists()
+        assert files.ddy.exists()
         assert files.stat is not None and files.stat.exists()
         assert files.station is station
         assert files.epw.suffix == ".epw"
@@ -205,7 +205,7 @@ class TestWeatherDownloaderMaxAge:
         station = _make_station()
 
         files = downloader.download(station)
-        assert files.epw is not None and files.epw.exists()
+        assert files.epw.exists()
         assert mock_urlopen.call_count == 1
 
     @patch("idfkit.weather.download.urlopen")
@@ -220,7 +220,7 @@ class TestWeatherDownloaderMaxAge:
         station = _make_station()
 
         files = downloader.download(station)
-        assert files.epw is not None and files.epw.exists()
+        assert files.epw.exists()
 
     @patch("idfkit.weather.download.urlopen")
     @patch("idfkit.weather.download.time")

--- a/tests/test_weather_download.py
+++ b/tests/test_weather_download.py
@@ -79,8 +79,8 @@ class TestWeatherDownloader:
         station = _make_station()
         files = downloader.download(station)
 
-        assert files.epw.exists()
-        assert files.ddy.exists()
+        assert files.epw is not None and files.epw.exists()
+        assert files.ddy is not None and files.ddy.exists()
         assert files.stat is not None and files.stat.exists()
         assert files.station is station
         assert files.epw.suffix == ".epw"
@@ -205,7 +205,7 @@ class TestWeatherDownloaderMaxAge:
         station = _make_station()
 
         files = downloader.download(station)
-        assert files.epw.exists()
+        assert files.epw is not None and files.epw.exists()
         assert mock_urlopen.call_count == 1
 
     @patch("idfkit.weather.download.urlopen")
@@ -220,7 +220,7 @@ class TestWeatherDownloaderMaxAge:
         station = _make_station()
 
         files = downloader.download(station)
-        assert files.epw.exists()
+        assert files.epw is not None and files.epw.exists()
 
     @patch("idfkit.weather.download.urlopen")
     @patch("idfkit.weather.download.time")
@@ -272,6 +272,81 @@ class TestWeatherDownloaderMaxAge:
         """_is_stale returns True for non-existent file when max_age is set (line 95)."""
         downloader = WeatherDownloader(cache_dir=tmp_path, max_age=3600.0)
         assert downloader._is_stale(tmp_path / "nonexistent.zip")  # pyright: ignore[reportPrivateUsage]
+
+
+class TestSelectiveExtraction:
+    """``download(only=...)`` extracts only the requested members."""
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_only_epw_skips_ddy_and_stat(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_bytes()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+        files = downloader.download(station, only={".epw"})
+
+        assert files.epw is not None and files.epw.exists()
+        assert files.ddy is None
+        assert files.stat is None
+        # Only the EPW landed on disk next to the ZIP.
+        siblings = sorted(p.suffix.lower() for p in files.zip_path.parent.iterdir() if p.is_file())
+        assert siblings == [".epw", ".zip"]
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_only_normalises_suffix_forms(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """Bare extension, missing dot, and uppercase all match the same members."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_bytes()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+        files = downloader.download(station, only=["EPW", ".DDY"])
+
+        assert files.epw is not None and files.epw.exists()
+        assert files.ddy is not None and files.ddy.exists()
+        assert files.stat is None
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_only_does_not_raise_when_member_missing(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """A missing requested member yields ``None``; selective mode never raises for that."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_without_ddy()  # has EPW, no DDY
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+        files = downloader.download(station, only={".ddy"})
+
+        assert files.ddy is None
+        # Full-extract requirement does NOT apply in selective mode.
+
+    @patch("idfkit.weather.download.urlopen")
+    def test_selective_after_full_returns_already_extracted(self, mock_urlopen: MagicMock, tmp_path: Path) -> None:
+        """If a prior full download cached every file, selective still surfaces them."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = _make_zip_bytes()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        downloader = WeatherDownloader(cache_dir=tmp_path)
+        station = _make_station()
+        downloader.download(station)  # full extract populates the cache dir
+        files = downloader.download(station, only={".epw"})
+
+        # We didn't request the DDY/stat, but they're on disk from the prior call.
+        assert files.epw is not None
+        assert files.ddy is not None
+        assert files.stat is not None
 
 
 class TestGetEpwByFilename:


### PR DESCRIPTION
## Summary

- New `only=` keyword on `WeatherDownloader.download()` extracts only the requested members from a TMY bundle (e.g. `only={".epw"}`), instead of always unpacking the full ZIP.
- Suffixes are normalised: `"epw"`, `".EPW"`, and `".epw"` all match `.epw` members.
- Selective mode never raises for a missing requested member — the corresponding `WeatherFiles` field is just `None`. Full extracts (no `only=`) still require `.epw` and `.ddy` and raise otherwise, preserving the previous contract.
- `WeatherFiles.epw` and `.ddy` are now typed `Path | None` to reflect that selective mode may legitimately omit them. `get_epw()` / `get_ddy()` still return non-`None` `Path` (full extract + internal assertion).
- Extraction logic refactored into a single `_ensure_extracted()` helper that handles both full and selective paths.

```python
files = downloader.download(station, only={".epw"})
# files.epw -> Path; files.ddy / files.stat -> None
```

## Test plan

- [x] `uv run pytest tests/test_weather_download.py -v` — 23/23 pass, including 4 new cases under `TestSelectiveExtraction`:
  - `test_only_epw_skips_ddy_and_stat`
  - `test_only_normalises_suffix_forms`
  - `test_only_does_not_raise_when_member_missing`
  - `test_selective_after_full_returns_already_extracted`
- [x] `uv run pytest tests/ -x -q` — full suite (3054 passed, 1 skipped)
- [x] `uv run pyright src/ docs/snippets` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)