### PR TITLE
typing(writers): narrow write_idf/write_epjson return type via @overload

### DIFF
--- a/src/idfkit/writers.py
+++ b/src/idfkit/writers.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,29 @@ def _resolve_version_identifier(doc: IDFDocument[bool]) -> str:
     return f"{v[0]}.{v[1]}"
 
 
+@overload
 def write_idf(
+    doc: IDFDocument[bool],
+    filepath: None = ...,
+    encoding: str = ...,
+    output_type: OutputType = ...,
+    *,
+    preserve_formatting: bool | None = ...,
+) -> str: ...
+
+
+@overload
+def write_idf(
+    doc: IDFDocument[bool],
+    filepath: Path | str,
+    encoding: str = ...,
+    output_type: OutputType = ...,
+    *,
+    preserve_formatting: bool | None = ...,
+) -> None: ...
+
+
+def write_idf(  # type: ignore[misc]  # overload implementation
     doc: IDFDocument[bool],
     filepath: Path | str | None = None,
     encoding: str = "latin-1",
@@ -129,7 +151,27 @@ def write_idf(
     return content
 
 
+@overload
 def write_epjson(
+    doc: IDFDocument[bool],
+    filepath: None = ...,
+    indent: int = ...,
+    *,
+    preserve_formatting: bool | None = ...,
+) -> str: ...
+
+
+@overload
+def write_epjson(
+    doc: IDFDocument[bool],
+    filepath: Path | str,
+    indent: int = ...,
+    *,
+    preserve_formatting: bool | None = ...,
+) -> None: ...
+
+
+def write_epjson(  # type: ignore[misc]  # overload implementation
     doc: IDFDocument[bool],
     filepath: Path | str | None = None,
     indent: int = 2,

--- a/src/idfkit/writers.py
+++ b/src/idfkit/writers.py
@@ -63,7 +63,7 @@ def write_idf(
 ) -> None: ...
 
 
-def write_idf(  # type: ignore[misc]  # overload implementation
+def write_idf(
     doc: IDFDocument[bool],
     filepath: Path | str | None = None,
     encoding: str = "latin-1",
@@ -171,7 +171,7 @@ def write_epjson(
 ) -> None: ...
 
 
-def write_epjson(  # type: ignore[misc]  # overload implementation
+def write_epjson(
     doc: IDFDocument[bool],
     filepath: Path | str | None = None,
     indent: int = 2,


### PR DESCRIPTION
## Summary

- Add `@overload` pairs to `write_idf` and `write_epjson` so callers get a precise return type at the call site.
- `filepath=None` (or omitted) → `-> str`; `filepath: Path | str` → `-> None`.
- Mirrors the existing overload pattern used by `load_idf` / `load_epjson` in `src/idfkit/__init__.py`.

The runtime implementation is unchanged — overloads are stripped at runtime, so existing doctests in `writers.py` and the rest of the test suite pass unmodified.

## Test plan

- [x] `make check` (ruff, pyright strict, deptry) — passes (0 errors)
- [x] `make test` — 3134 passed, 1 skipped
- [x] Existing doctests in `write_idf` (`>>> idf_str = write_idf(model)`) and `write_epjson` (`>>> json_str = write_epjson(model)`) still pass — both call patterns match the no-filepath overload returning `str`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)