### PR TITLE
typing(objects): narrow IDFCollection.get return type via @overload

### DIFF
--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from ._compat_object import EppyObjectMixin
 from .exceptions import InvalidFieldError
@@ -1012,7 +1012,18 @@ class IDFCollection(Generic[_T]):
     def __repr__(self) -> str:
         return f"IDFCollection({self._type}, count={len(self._items)})"
 
-    def get(self, name: str, default: _T | None = None) -> _T | None:
+    @overload
+    def get(self, name: str) -> _T | None: ...
+
+    @overload
+    def get(self, name: str, default: _T) -> _T: ...
+
+    @overload
+    def get(self, name: str, default: None) -> _T | None: ...
+
+    def get(  # type: ignore[misc]  # overload implementation
+        self, name: str, default: _T | None = None
+    ) -> _T | None:
         """Get object by name with default.
 
         For unnamed/singleton object types (e.g. SimulationControl), pass an

--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -1021,9 +1021,7 @@ class IDFCollection(Generic[_T]):
     @overload
     def get(self, name: str, default: None) -> _T | None: ...
 
-    def get(  # type: ignore[misc]  # overload implementation
-        self, name: str, default: _T | None = None
-    ) -> _T | None:
+    def get(self, name: str, default: _T | None = None) -> _T | None:
         """Get object by name with default.
 
         For unnamed/singleton object types (e.g. SimulationControl), pass an


### PR DESCRIPTION
## Summary

- Add three `@overload` variants on `IDFCollection.get`, matching the canonical typeshed pattern for `Mapping.get`:
  - `get(name) -> _T | None` (default omitted)
  - `get(name, default: _T) -> _T` (non-None default — never returns None)
  - `get(name, default: None) -> _T | None` (explicit None default)
- Callers passing a non-None default no longer need to handle a phantom `None` branch.

The runtime implementation is unchanged. All four existing doctests for `IDFCollection.get` continue to pass — they exercise the no-default overload variant.

## Test plan

- [x] `make check` (ruff, pyright strict, deptry) — passes (0 errors)
- [x] `make test` — 3134 passed, 1 skipped
- [x] Existing doctests for `IDFCollection.get` (`>>> model["Zone"].get("Perimeter_ZN_1").name`, `>>> model["Zone"].get("NonExistent") is None`, `>>> model["SimulationControl"].get("") is not None`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)