### PR TITLE
typing(simulation/sql): narrow TimeSeriesResult.plot backend parameter

### DIFF
--- a/src/idfkit/simulation/parsers/sql.py
+++ b/src/idfkit/simulation/parsers/sql.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     import pandas as pd
 
+    from ..plotting import PlotBackend
+
 # EnergyPlus uses a fixed reference year for timestamps. 2017 is the canonical
 # non-leap year used by convention.
 _REFERENCE_YEAR = 2017
@@ -61,7 +63,7 @@ class TimeSeriesResult:
             {"timestamp": list(self.timestamps), self.variable_name: list(self.values)}
         ).set_index("timestamp")
 
-    def plot(self, *, backend: Any = None, title: str | None = None) -> Any:
+    def plot(self, *, backend: PlotBackend | None = None, title: str | None = None) -> Any:
         """Plot this time series as a line chart.
 
         Auto-detects the plotting backend if not provided. Requires matplotlib


### PR DESCRIPTION
## Summary

- Replace `backend: Any = None` with `backend: PlotBackend | None = None` on `TimeSeriesResult.plot`, importing the Protocol under `TYPE_CHECKING`.
- Return type stays `-> Any` because `PlotBackend.line` itself returns `Any` (matplotlib `Figure` and plotly `Figure` don't share a common base, and inventing a unified Figure Protocol is out of scope for this focused typing sweep).
- Narrowing the parameter alone still helps callers — passing a non-`PlotBackend` object will now be flagged at the call site.

Runtime behavior is unchanged.

## Test plan

- [x] `make check` (ruff, pyright strict, deptry) — passes (0 errors)
- [x] `make test` — 3134 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)