### PR TITLE
typing: drop vestigial # type: ignore[misc] on overload implementations

### DIFF
--- a/src/idfkit/__init__.py
+++ b/src/idfkit/__init__.py
@@ -183,7 +183,7 @@ def load_idf(
 ) -> IDFDocument[Literal[False]]: ...
 
 
-def load_idf(  # type: ignore[misc]  # overload implementation
+def load_idf(
     path: str,
     version: tuple[int, int, int] | None = None,
     *,
@@ -264,7 +264,7 @@ def load_epjson(
 ) -> IDFDocument[Literal[False]]: ...
 
 
-def load_epjson(  # type: ignore[misc]  # overload implementation
+def load_epjson(
     path: str,
     version: tuple[int, int, int] | None = None,
     *,
@@ -325,7 +325,7 @@ def new_document(
 ) -> IDFDocument[Literal[False]]: ...
 
 
-def new_document(  # type: ignore[misc]  # overload implementation
+def new_document(
     version: tuple[int, int, int] = LATEST_VERSION,
     *,
     strict: bool = True,


### PR DESCRIPTION
## Summary

Remove the `# type: ignore[misc]  # overload implementation` comments from the three exemplar overloads in `src/idfkit/__init__.py`: `load_idf`, `load_epjson`, and `new_document`.

`[misc]` is a **mypy** error code. This project type-checks with **pyright only** (`make check` runs `uv run pyright src/ docs/snippets`; CI matches), and pyright accepts the overload implementations cleanly without the suppression. The comments are vestigial — likely from an earlier toolchain that included mypy.

Companion to #145 (writers) and #146 (objects), which dropped the same comments from the new overloads added in this typing sweep.

## Test plan

- [x] `make check` (ruff, pyright strict, deptry) — passes (0 errors)
- [x] `make test` — 3134 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)