### PR TITLE
fix(objects): preserve wrapper_key + ext_inner_names in IDFObject.copy

### DIFF
--- a/src/idfkit/objects.py
+++ b/src/idfkit/objects.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 import warnings
 from collections.abc import Callable, Iterator
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 from ._compat_object import EppyObjectMixin
@@ -463,7 +464,19 @@ class IDFObject(EppyObjectMixin):
         object.__setattr__(self, "_data", data if data is not None else {})
         object.__setattr__(self, "_schema", schema)
         object.__setattr__(self, "_document", document)
-        object.__setattr__(self, "_extensibles", extensibles or frozenset())
+        # Invariant: extensible metadata must be passed as a complete bundle.
+        # Having ext_field_names without a wrapper_key/inner_names trio means
+        # obj.<wrapper_key> falls back to returning the raw list of dicts
+        # instead of an ExtensibleList — a silent foot-gun that surfaces
+        # later as 'dict' object has no attribute '<inner_field>'.
+        ext_set = extensibles or frozenset()
+        if ext_set and (wrapper_key is None or not ext_inner_names):
+            raise ValueError(  # noqa: TRY003
+                f"{obj_type}: inconsistent extensible metadata — "
+                f"extensibles={sorted(ext_set)!r} requires both "
+                f"wrapper_key (got {wrapper_key!r}) and ext_inner_names (got {ext_inner_names!r})"
+            )
+        object.__setattr__(self, "_extensibles", ext_set)
         object.__setattr__(self, "_field_order", field_order)
         object.__setattr__(self, "_ref_fields", ref_fields)
         object.__setattr__(self, "_source_text", source_text)
@@ -825,13 +838,15 @@ class IDFObject(EppyObjectMixin):
         return IDFObject(
             obj_type=self._type,
             name=self._name,
-            data=dict(self._data),
+            data=deepcopy(self._data),
             schema=self._schema,
             document=None,  # Don't copy document reference
             field_order=list(self._field_order) if self._field_order is not None else None,
             ref_fields=self._ref_fields,
             source_text=None,  # copy is a new object; don't carry over verbatim text
             extensibles=self._extensibles,
+            wrapper_key=self._wrapper_key,
+            ext_inner_names=self._ext_inner_names,
         )
 
     def __dir__(self) -> list[str]:

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -203,6 +203,55 @@ class TestIDFObject:
         copied = obj.copy()
         assert copied.theidf is None
 
+    def test_copy_preserves_extensible_wrapper(self) -> None:
+        """Regression: copy() must forward wrapper_key and ext_inner_names so
+        the typed ExtensibleList view keeps working on the copy. Otherwise
+        ``obj.<wrapper>`` falls through to ``data[<wrapper>]`` and yields
+        plain dicts on iteration — breaking any caller that touched the
+        copied object via the typed API."""
+        obj = IDFObject(
+            obj_type="Output:Table:SummaryReports",
+            name="",
+            data={"reports": [{"report_name": "AllSummary"}]},
+            extensibles=frozenset({"report_name"}),
+            wrapper_key="reports",
+            ext_inner_names=("report_name",),
+        )
+        copied = obj.copy()
+        assert copied._wrapper_key == "reports"
+        assert copied._ext_inner_names == ("report_name",)
+        # Iteration via the typed API yields ExtensibleGroup, not raw dicts.
+        names = {group.report_name for group in copied.reports}
+        assert names == {"AllSummary"}
+
+    def test_copy_data_is_deep(self) -> None:
+        """copy() must deep-copy data so mutating extensible groups on the
+        copy does not bleed back into the original."""
+        obj = IDFObject(
+            obj_type="Output:Table:SummaryReports",
+            name="",
+            data={"reports": [{"report_name": "AllSummary"}]},
+            extensibles=frozenset({"report_name"}),
+            wrapper_key="reports",
+            ext_inner_names=("report_name",),
+        )
+        copied = obj.copy()
+        copied.reports.append({"report_name": "HVACSizingSummary"})
+        assert [g.report_name for g in obj.reports] == ["AllSummary"]
+        assert [g.report_name for g in copied.reports] == ["AllSummary", "HVACSizingSummary"]
+
+    def test_init_rejects_inconsistent_extensible_metadata(self) -> None:
+        """Defensive guard: extensibles must come bundled with wrapper_key
+        and ext_inner_names. A partial trio is the precise failure mode that
+        used to surface as 'dict' has no attribute '<inner_field>' downstream."""
+        with pytest.raises(ValueError, match="inconsistent extensible metadata"):
+            IDFObject(
+                obj_type="Output:Table:SummaryReports",
+                name="",
+                extensibles=frozenset({"report_name"}),
+                # wrapper_key and ext_inner_names omitted on purpose
+            )
+
     def test_fieldnames_with_field_order(self) -> None:
         obj = IDFObject(
             obj_type="Zone",
@@ -576,6 +625,8 @@ class TestIDFObjectStrict:
             name="Z",
             field_order=["field_one"],
             extensibles=frozenset({"other"}),
+            wrapper_key="entries",
+            ext_inner_names=("other",),
         )
         # "vertex_1_x_coordinate" doesn't match extensibles → check "base_N" path
         assert not obj._is_known_field("vertex_1_x_coordinate", ["field_one"])  # pyright: ignore[reportPrivateUsage]
@@ -587,6 +638,8 @@ class TestIDFObjectStrict:
             name="Z",
             field_order=["field"],
             extensibles=frozenset({"field"}),
+            wrapper_key="entries",
+            ext_inner_names=("field",),
         )
         # Write a field that has no extensible pattern match — value stored in _data
         obj._set_field("completely_unknown_field_xyz", 42.0)  # pyright: ignore[reportPrivateUsage]
@@ -610,6 +663,8 @@ class TestObjectsAdditionalBranches:
             name="Z",
             field_order=["other"],
             extensibles=frozenset({"other"}),
+            wrapper_key="entries",
+            ext_inner_names=("other",),
         )
         # "myfield_5" matches base_N pattern; base="myfield" NOT in extensibles
         result = obj._is_known_field("myfield_5", ["other"])  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary
- `IDFObject.copy()` was forwarding `extensibles` but silently dropping the matching `wrapper_key` and `ext_inner_names`. After `doc.copy()`, every copied object had `_wrapper_key=None`, so attribute access on a wrapper field (e.g. `obj.reports` on `Output:Table:SummaryReports`) fell through `__getattr__`'s extensible-list branch and returned the raw `data[wrapper_key]` list of dicts. Iteration yielded plain dicts and downstream code blew up with `'dict' object has no attribute '<inner_field>'`.
- Bonus fix: `copy()` now uses `deepcopy(data)` instead of a shallow `dict(data)` — the wrapper list and inner dicts were shared between original and copy, so mutating one bled into the other.
- Defensive guard in `IDFObject.__init__`: a non-empty `extensibles` set without a matching `wrapper_key`/`ext_inner_names` is the precise shape that produces the silent dict-iteration foot-gun. We now fail loud at construction time instead of letting it surface as a confusing downstream AttributeError.

## Concrete failure path
`idfkit-mcp`'s `_ensure_summary_reports` runs on `sim_doc = doc.copy()` and iterates `obj.reports` to compute the set of existing report names — instant `AttributeError` on every simulation whose loaded model already had `Output:Table:SummaryReports`:

```
File "src/idfkit_mcp/tools/simulation.py", line 174, in _ensure_summary_reports
    existing = {group.report_name for group in obj.reports if group.report_name is not None}
                                                              ^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'report_name'
```

## Test plan
- [x] `tests/test_objects.py::test_copy_preserves_extensible_wrapper` regresses the original bug
- [x] `tests/test_objects.py::test_copy_data_is_deep` regresses the shallow-copy bleed-through
- [x] `tests/test_objects.py::test_init_rejects_inconsistent_extensible_metadata` covers the constructor guard
- [x] Full suite: 3057 passed, 1 skipped (no regressions)
- [x] `pyright src/`: 0 new errors (60 pre-existing in `simulation/parsers/sql.py` on `main`)
- [x] `ruff check` / `ruff format`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)