### PR TITLE
Add preprocessor_timeout parameter for ground heat-transfer preprocessing

### DIFF
--- a/docs/concepts/environment-variables.md
+++ b/docs/concepts/environment-variables.md
@@ -26,6 +26,31 @@ to locate the `energyplus` executable.
 See [Installation › EnergyPlus Installation](../getting-started/installation.md#energyplus-installation)
 for the full discovery order.
 
+### `IDFKIT_PREPROCESSOR_TIMEOUT`
+
+Per-subprocess timeout (in seconds) applied to the ExpandObjects, Slab,
+and Basement preprocessors when [`simulate()`](../api/simulation/runner.md)
+runs them automatically. Useful for raising the ceiling on slow shared
+hardware with complex slab/basement geometries, or lowering it in CI to
+catch hangs quickly.
+
+- **Read in:** `idfkit.simulation._common`
+- **Default:** unset — falls back to **120 seconds** per subprocess.
+- **Activation:** set to a positive number of seconds. Invalid or
+  non-positive values raise `ValueError` at simulation time.
+- **Override:** the `preprocessor_timeout` argument to `simulate()`,
+  `async_simulate()`, and `SimulationJob` always wins over this variable.
+- **Note:** independent of the `timeout` argument — there is no shared
+  wall-clock budget across the pipeline. Each preprocessor stage gets its
+  own fresh window, and EnergyPlus then gets `timeout` seconds for the
+  main run.
+- **Example:**
+
+    ```bash
+    export IDFKIT_PREPROCESSOR_TIMEOUT=600   # slow shared hardware
+    export IDFKIT_PREPROCESSOR_TIMEOUT=30    # fail fast in CI
+    ```
+
 ### `IDFKIT_NO_WEATHER_UPDATE_CHECK`
 
 Opt-out flag that suppresses the once-per-day freshness nudge emitted when
@@ -88,6 +113,7 @@ fallback root when scanning for `EnergyPlusV*` installs at the drive root.
 | Variable                          | Purpose                                | Default                              |
 |-----------------------------------|----------------------------------------|--------------------------------------|
 | `ENERGYPLUS_DIR`                  | EnergyPlus install path                | unset (PATH + platform defaults)     |
+| `IDFKIT_PREPROCESSOR_TIMEOUT`     | Per-subprocess preprocessor timeout    | unset (120 s)                        |
 | `IDFKIT_NO_WEATHER_UPDATE_CHECK`  | Disable weather index freshness nudge  | unset (check enabled)                |
 | `XDG_CACHE_HOME`                  | Linux cache root                       | `~/.cache`                           |
 | `LOCALAPPDATA`                    | Windows cache root                     | `%UserProfile%\AppData\Local`        |

--- a/docs/simulation/async.md
+++ b/docs/simulation/async.md
@@ -193,6 +193,11 @@ When `expand_objects=True` (the default), the Slab and Basement
 preprocessors run in a background thread via `asyncio.to_thread()` so they
 don't block the event loop.  This is transparent — no user action required.
 
+`async_simulate` accepts a `preprocessor_timeout` argument that mirrors
+[`simulate()`'s](running.md#preprocessor-timeout); pass an explicit value
+or set the `IDFKIT_PREPROCESSOR_TIMEOUT` environment variable to override
+the per-subprocess 120 s default.
+
 ## Error Handling
 
 Error handling is identical to the sync API:

--- a/docs/simulation/batch.md
+++ b/docs/simulation/batch.md
@@ -32,7 +32,8 @@ Define individual simulations with `SimulationJob`:
 | `output_prefix` | `str` | `"eplus"` | Output file prefix |
 | `output_suffix` | <code>"C" &#124; "L" &#124; "D"</code> | `"C"` | Output naming style |
 | `readvars` | `bool` | `False` | Run ReadVarsESO |
-| `timeout` | `float` | `3600.0` | Max runtime (seconds) |
+| `timeout` | `float` | `3600.0` | Max runtime (seconds) for the EnergyPlus subprocess |
+| `preprocessor_timeout` | <code>float &#124; None</code> | `None` | Per-subprocess timeout for ExpandObjects / Slab / Basement.  `None` reads `IDFKIT_PREPROCESSOR_TIMEOUT` (default 120 s) — see [Running Simulations › Preprocessor Timeout](running.md#preprocessor-timeout) |
 | `extra_args` | <code>tuple[str, ...] &#124; None</code> | `None` | Extra CLI args |
 
 ## Parametric Studies

--- a/docs/simulation/running.md
+++ b/docs/simulation/running.md
@@ -66,6 +66,30 @@ objects need the Slab or Basement preprocessor to compute ground temperatures.
     contains the corresponding ground heat-transfer objects.  In most
     cases you do not need to call these functions yourself.
 
+#### Preprocessor Timeout
+
+Each preprocessor stage (ExpandObjects, Slab, Basement) gets its own
+subprocess timeout, separate from the EnergyPlus `timeout`.  Override it
+per call with `preprocessor_timeout`:
+
+```python
+simulate(model, weather, preprocessor_timeout=600.0)  # 10 min per stage
+```
+
+Or set a process-wide default with the `IDFKIT_PREPROCESSOR_TIMEOUT`
+environment variable — useful for slow shared hardware (raise it) or
+fast CI where you want to catch hangs quickly (lower it):
+
+```bash
+export IDFKIT_PREPROCESSOR_TIMEOUT=600   # slow shared hardware
+export IDFKIT_PREPROCESSOR_TIMEOUT=30    # fail fast in CI
+```
+
+The default is **120 seconds per subprocess**.  `timeout` and
+`preprocessor_timeout` are independent budgets — there is no shared
+wall-clock cap across the pipeline, so a long `preprocessor_timeout`
+will not trip the simulation's `timeout` and vice versa.
+
 For cases where you need to inspect or modify the preprocessed model
 before simulation, standalone functions are available:
 
@@ -101,6 +125,7 @@ def simulate(
     output_suffix: Literal["C", "L", "D"] = "C",
     readvars: bool = False,
     timeout: float = 3600.0,
+    preprocessor_timeout: float | None = None,
     extra_args: list[str] | None = None,
     cache: SimulationCache | None = None,
     fs: FileSystem | None = None,
@@ -130,7 +155,8 @@ def simulate(
 | `output_prefix` | `"eplus"` | Prefix for output files |
 | `output_suffix` | `"C"` | Output naming style (C/L/D) |
 | `readvars` | `False` | Run ReadVarsESO after simulation |
-| `timeout` | `3600.0` | Maximum runtime in seconds |
+| `timeout` | `3600.0` | Maximum runtime in seconds (main EnergyPlus subprocess only) |
+| `preprocessor_timeout` | `None` | Per-subprocess timeout for ExpandObjects / Slab / Basement.  `None` reads `IDFKIT_PREPROCESSOR_TIMEOUT`, defaulting to 120 s |
 | `extra_args` | `None` | Additional command-line arguments |
 | `cache` | `None` | Simulation cache for result reuse |
 | `fs` | `None` | File system backend for cloud storage |

--- a/src/idfkit/simulation/_common.py
+++ b/src/idfkit/simulation/_common.py
@@ -5,12 +5,60 @@ Internal module — not part of the public API.
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from .config import EnergyPlusConfig, find_energyplus
+
+PREPROCESSOR_TIMEOUT_ENV = "IDFKIT_PREPROCESSOR_TIMEOUT"
+DEFAULT_PREPROCESSOR_TIMEOUT = 120.0
+
+
+def resolve_preprocessor_timeout(explicit: float | None) -> float:
+    """Resolve the preprocessor timeout for a single subprocess invocation.
+
+    Resolution order:
+
+    1. *explicit* if not ``None`` (caller-supplied value).
+    2. ``IDFKIT_PREPROCESSOR_TIMEOUT`` environment variable, parsed as
+       a float.
+    3. ``DEFAULT_PREPROCESSOR_TIMEOUT`` (120 seconds).
+
+    Args:
+        explicit: Caller-supplied value, or ``None`` to defer to the
+            environment / default.
+
+    Returns:
+        The timeout in seconds applied to each preprocessor subprocess
+        (ExpandObjects, Slab, Basement). The value is per-invocation, not
+        a shared budget across the pipeline.
+
+    Raises:
+        ValueError: If ``IDFKIT_PREPROCESSOR_TIMEOUT`` is set but cannot
+            be parsed as a positive float.
+    """
+    if explicit is not None:
+        return explicit
+
+    env_value = os.environ.get(PREPROCESSOR_TIMEOUT_ENV)
+    if env_value is None or env_value == "":
+        return DEFAULT_PREPROCESSOR_TIMEOUT
+
+    try:
+        parsed = float(env_value)
+    except ValueError as exc:
+        msg = f"{PREPROCESSOR_TIMEOUT_ENV} must be a positive number of seconds, got {env_value!r}"
+        raise ValueError(msg) from exc
+
+    if parsed <= 0:
+        msg = f"{PREPROCESSOR_TIMEOUT_ENV} must be a positive number of seconds, got {parsed}"
+        raise ValueError(msg)
+
+    return parsed
+
 
 if TYPE_CHECKING:
     from ..document import IDFDocument
@@ -157,6 +205,7 @@ def maybe_preprocess(
     config: EnergyPlusConfig,
     weather_path: Path,
     expand_objects: bool,
+    preprocessor_timeout: float | None = None,
 ) -> tuple[IDFDocument, bool]:
     """Run ground heat-transfer preprocessing if needed.
 
@@ -172,6 +221,10 @@ def maybe_preprocess(
         config: EnergyPlus configuration.
         weather_path: Resolved path to the weather file.
         expand_objects: Whether the caller requested expansion.
+        preprocessor_timeout: Per-subprocess timeout (seconds) applied to
+            ExpandObjects, Slab, and Basement individually. ``None`` defers
+            to [resolve_preprocessor_timeout][idfkit.simulation._common.resolve_preprocessor_timeout]
+            (env var ``IDFKIT_PREPROCESSOR_TIMEOUT`` or 120 s default).
 
     Returns:
         A ``(model, ep_expand)`` tuple where *model* is either the
@@ -189,6 +242,7 @@ def maybe_preprocess(
             sim_model,
             energyplus=config,
             weather=weather_path,
+            timeout=resolve_preprocessor_timeout(preprocessor_timeout),
         )
         return preprocessed, False  # Already expanded by preprocessing
 

--- a/src/idfkit/simulation/async_batch.py
+++ b/src/idfkit/simulation/async_batch.py
@@ -303,6 +303,7 @@ async def _async_run_job(
             output_suffix=job.output_suffix,
             readvars=job.readvars,
             timeout=job.timeout,
+            preprocessor_timeout=job.preprocessor_timeout,
             extra_args=list(job.extra_args) if job.extra_args else None,
             cache=cache,
             fs=fs,

--- a/src/idfkit/simulation/async_runner.py
+++ b/src/idfkit/simulation/async_runner.py
@@ -77,6 +77,7 @@ async def async_simulate(
     output_suffix: Literal["C", "L", "D"] = "C",
     readvars: bool = False,
     timeout: float = 3600.0,
+    preprocessor_timeout: float | None = None,
     extra_args: list[str] | None = None,
     cache: SimulationCache | None = None,
     fs: FileSystem | AsyncFileSystem | None = None,
@@ -109,7 +110,14 @@ async def async_simulate(
             files (default), ``"L"`` for legacy separate table files, or
             ``"D"`` for timestamped separate files.
         readvars: Run ReadVarsESO after simulation (``-r`` flag).
-        timeout: Maximum runtime in seconds (default 3600).
+        timeout: Maximum runtime in seconds (default 3600).  Applied only
+            to the main EnergyPlus subprocess; preprocessor stages have an
+            independent budget — see *preprocessor_timeout*.
+        preprocessor_timeout: Per-subprocess timeout (seconds) applied
+            individually to ExpandObjects, Slab, and Basement when they
+            run automatically.  ``None`` (the default) consults the
+            ``IDFKIT_PREPROCESSOR_TIMEOUT`` environment variable, falling
+            back to 120 s.  Independent of *timeout*.
         extra_args: Additional command-line arguments.
         cache: Optional simulation cache for content-hash lookups.
         fs: Optional file system backend for storing results on remote
@@ -187,7 +195,13 @@ async def async_simulate(
         # Preprocessing may invoke subprocesses synchronously — delegate to a
         # thread so we don't block the event loop.
         sim_model, ep_expand = await asyncio.to_thread(
-            maybe_preprocess, sim_input_model, sim_model, config, weather_path, expand_objects
+            maybe_preprocess,
+            sim_input_model,
+            sim_model,
+            config,
+            weather_path,
+            expand_objects,
+            preprocessor_timeout,
         )
 
         # When using a remote fs, always run locally in a temp dir

--- a/src/idfkit/simulation/batch.py
+++ b/src/idfkit/simulation/batch.py
@@ -46,7 +46,13 @@ class SimulationJob:
         output_prefix: Prefix for output files.
         output_suffix: Output file naming suffix (``"C"``, ``"L"``, or ``"D"``).
         readvars: Run ReadVarsESO after simulation.
-        timeout: Maximum runtime in seconds.
+        timeout: Maximum runtime in seconds for the main EnergyPlus
+            subprocess.
+        preprocessor_timeout: Per-subprocess timeout (seconds) applied
+            individually to ExpandObjects, Slab, and Basement when they
+            run automatically.  ``None`` consults the
+            ``IDFKIT_PREPROCESSOR_TIMEOUT`` environment variable, falling
+            back to 120 s.
         extra_args: Additional command-line arguments.
     """
 
@@ -61,6 +67,7 @@ class SimulationJob:
     output_suffix: Literal["C", "L", "D"] = "C"
     readvars: bool = False
     timeout: float = 3600.0
+    preprocessor_timeout: float | None = None
     extra_args: tuple[str, ...] | None = None
 
 
@@ -237,6 +244,7 @@ def _run_job(
             output_suffix=job.output_suffix,
             readvars=job.readvars,
             timeout=job.timeout,
+            preprocessor_timeout=job.preprocessor_timeout,
             extra_args=list(job.extra_args) if job.extra_args else None,
             cache=cache,
             fs=fs,

--- a/src/idfkit/simulation/runner.py
+++ b/src/idfkit/simulation/runner.py
@@ -48,6 +48,7 @@ def simulate(
     output_suffix: Literal["C", "L", "D"] = "C",
     readvars: bool = False,
     timeout: float = 3600.0,
+    preprocessor_timeout: float | None = None,
     extra_args: list[str] | None = None,
     cache: SimulationCache | None = None,
     fs: FileSystem | None = None,
@@ -83,7 +84,16 @@ def simulate(
             files (default), ``"L"`` for legacy separate table files, or
             ``"D"`` for timestamped separate files.
         readvars: Run ReadVarsESO after simulation (``-r`` flag).
-        timeout: Maximum runtime in seconds (default 3600).
+        timeout: Maximum runtime in seconds (default 3600).  Applied only
+            to the main EnergyPlus subprocess; preprocessor stages
+            (ExpandObjects, Slab, Basement) have an independent budget — see
+            *preprocessor_timeout*.
+        preprocessor_timeout: Per-subprocess timeout (seconds) applied
+            individually to ExpandObjects, Slab, and Basement when they
+            run automatically.  ``None`` (the default) consults the
+            ``IDFKIT_PREPROCESSOR_TIMEOUT`` environment variable, falling
+            back to 120 s.  Independent of *timeout* — there is no shared
+            wall-clock cap across the pipeline.
         extra_args: Additional command-line arguments.
         cache: Optional simulation cache for content-hash lookups.
         fs: Optional file system backend for storing results on remote
@@ -171,7 +181,14 @@ def simulate(
         ensure_sql_output(sim_model)
 
         # Auto-preprocess ground heat-transfer objects when needed.
-        sim_model, ep_expand = maybe_preprocess(sim_input_model, sim_model, config, weather_path, expand_objects)
+        sim_model, ep_expand = maybe_preprocess(
+            sim_input_model,
+            sim_model,
+            config,
+            weather_path,
+            expand_objects,
+            preprocessor_timeout=preprocessor_timeout,
+        )
 
         # When using a remote fs, always run locally in a temp dir
         local_output_dir = None if fs is not None else output_dir

--- a/tests/test_simulation_preprocessor_timeout.py
+++ b/tests/test_simulation_preprocessor_timeout.py
@@ -1,0 +1,219 @@
+"""Tests for the preprocessor_timeout parameter and IDFKIT_PREPROCESSOR_TIMEOUT env var.
+
+Covers the resolution helper plus the forwarding through ``simulate()``,
+``async_simulate()``, and the batch entry points.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from idfkit import LATEST_VERSION, new_document
+from idfkit.simulation._common import (
+    DEFAULT_PREPROCESSOR_TIMEOUT,
+    PREPROCESSOR_TIMEOUT_ENV,
+    resolve_preprocessor_timeout,
+)
+from idfkit.simulation.async_runner import async_simulate
+from idfkit.simulation.batch import SimulationJob, simulate_batch
+from idfkit.simulation.config import EnergyPlusConfig
+from idfkit.simulation.runner import simulate
+
+
+@pytest.fixture
+def mock_config(tmp_path: Path) -> EnergyPlusConfig:
+    """Mock EnergyPlusConfig with the executables required for preprocessing."""
+    exe = tmp_path / "energyplus"
+    exe.touch()
+    exe.chmod(0o755)
+    idd = tmp_path / "Energy+.idd"
+    idd.write_text("!IDD_Version 24.1.0\n")
+
+    expand_exe = tmp_path / "ExpandObjects"
+    expand_exe.touch()
+    expand_exe.chmod(0o755)
+
+    preprocess = tmp_path / "PreProcess" / "GrndTempCalc"
+    preprocess.mkdir(parents=True)
+    slab_exe = preprocess / "Slab"
+    slab_exe.touch()
+    slab_exe.chmod(0o755)
+    (preprocess / "SlabGHT.idd").write_text("! Slab IDD\n")
+    basement_exe = preprocess / "Basement"
+    basement_exe.touch()
+    basement_exe.chmod(0o755)
+    (preprocess / "BasementGHT.idd").write_text("! Basement IDD\n")
+
+    return EnergyPlusConfig(
+        executable=exe,
+        version=LATEST_VERSION,
+        install_dir=tmp_path,
+        idd_path=idd,
+    )
+
+
+@pytest.fixture
+def weather_file(tmp_path: Path) -> Path:
+    epw = tmp_path / "weather.epw"
+    epw.write_text("LOCATION,Test,US,Test,USA_TX,12345,30.0,-95.0,-6.0,10.0\n")
+    return epw
+
+
+@pytest.fixture
+def slab_model():
+    model = new_document(version=LATEST_VERSION)
+    model.add("GroundHeatTransfer:Slab:Materials", "", {}, validate=False)
+    model.add("Zone", "Office", {"x_origin": 0.0})
+    return model
+
+
+# ---------------------------------------------------------------------------
+# resolve_preprocessor_timeout()
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePreprocessorTimeout:
+    def test_explicit_value_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "999")
+        assert resolve_preprocessor_timeout(42.0) == 42.0
+
+    def test_falls_back_to_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "300")
+        assert resolve_preprocessor_timeout(None) == 300.0
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(PREPROCESSOR_TIMEOUT_ENV, raising=False)
+        assert resolve_preprocessor_timeout(None) == DEFAULT_PREPROCESSOR_TIMEOUT
+
+    def test_default_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "")
+        assert resolve_preprocessor_timeout(None) == DEFAULT_PREPROCESSOR_TIMEOUT
+
+    def test_invalid_env_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "not-a-number")
+        with pytest.raises(ValueError, match=PREPROCESSOR_TIMEOUT_ENV):
+            resolve_preprocessor_timeout(None)
+
+    def test_non_positive_env_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "0")
+        with pytest.raises(ValueError, match="positive"):
+            resolve_preprocessor_timeout(None)
+
+    def test_explicit_value_bypasses_invalid_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit caller value is returned even if env var is malformed (never read)."""
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "garbage")
+        assert resolve_preprocessor_timeout(60.0) == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Forwarding through simulate()
+# ---------------------------------------------------------------------------
+
+
+class TestSimulateForwarding:
+    def test_explicit_timeout_forwarded(self, mock_config: EnergyPlusConfig, weather_file: Path, slab_model) -> None:
+        preprocessed = new_document(version=LATEST_VERSION)
+        preprocessed.add("Zone", "Office", {"x_origin": 0.0})
+        sim_proc = MagicMock(returncode=0, stdout="ok", stderr="")
+
+        with (
+            patch("idfkit.simulation.expand.run_preprocessing", return_value=preprocessed) as mock_pp,
+            patch("idfkit.simulation.runner.subprocess.run", return_value=sim_proc),
+        ):
+            simulate(slab_model, weather_file, energyplus=mock_config, preprocessor_timeout=300.0)
+
+        assert mock_pp.call_args.kwargs["timeout"] == 300.0
+
+    def test_env_var_used_when_param_omitted(
+        self,
+        mock_config: EnergyPlusConfig,
+        weather_file: Path,
+        slab_model,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(PREPROCESSOR_TIMEOUT_ENV, "450")
+        preprocessed = new_document(version=LATEST_VERSION)
+        preprocessed.add("Zone", "Office", {"x_origin": 0.0})
+        sim_proc = MagicMock(returncode=0, stdout="ok", stderr="")
+
+        with (
+            patch("idfkit.simulation.expand.run_preprocessing", return_value=preprocessed) as mock_pp,
+            patch("idfkit.simulation.runner.subprocess.run", return_value=sim_proc),
+        ):
+            simulate(slab_model, weather_file, energyplus=mock_config)
+
+        assert mock_pp.call_args.kwargs["timeout"] == 450.0
+
+    def test_default_when_unset(
+        self,
+        mock_config: EnergyPlusConfig,
+        weather_file: Path,
+        slab_model,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(PREPROCESSOR_TIMEOUT_ENV, raising=False)
+        preprocessed = new_document(version=LATEST_VERSION)
+        preprocessed.add("Zone", "Office", {"x_origin": 0.0})
+        sim_proc = MagicMock(returncode=0, stdout="ok", stderr="")
+
+        with (
+            patch("idfkit.simulation.expand.run_preprocessing", return_value=preprocessed) as mock_pp,
+            patch("idfkit.simulation.runner.subprocess.run", return_value=sim_proc),
+        ):
+            simulate(slab_model, weather_file, energyplus=mock_config)
+
+        assert mock_pp.call_args.kwargs["timeout"] == DEFAULT_PREPROCESSOR_TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# Forwarding through async_simulate()
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncSimulateForwarding:
+    def test_explicit_timeout_forwarded(self, mock_config: EnergyPlusConfig, weather_file: Path, slab_model) -> None:
+        preprocessed = new_document(version=LATEST_VERSION)
+        preprocessed.add("Zone", "Office", {"x_origin": 0.0})
+
+        async def fake_simple(_cmd: list[str], _cwd: Path, _timeout: float):
+            return "ok", "", 0
+
+        with (
+            patch("idfkit.simulation.expand.run_preprocessing", return_value=preprocessed) as mock_pp,
+            patch("idfkit.simulation.async_runner._run_simple", side_effect=fake_simple),
+        ):
+            asyncio.run(async_simulate(slab_model, weather_file, energyplus=mock_config, preprocessor_timeout=222.0))
+
+        assert mock_pp.call_args.kwargs["timeout"] == 222.0
+
+
+# ---------------------------------------------------------------------------
+# Forwarding through SimulationJob / simulate_batch()
+# ---------------------------------------------------------------------------
+
+
+class TestBatchForwarding:
+    def test_simulationjob_default_is_none(self) -> None:
+        model = new_document(version=LATEST_VERSION)
+        job = SimulationJob(model=model, weather="weather.epw")
+        assert job.preprocessor_timeout is None
+
+    def test_batch_forwards_per_job_timeout(
+        self, mock_config: EnergyPlusConfig, weather_file: Path, slab_model
+    ) -> None:
+        preprocessed = new_document(version=LATEST_VERSION)
+        preprocessed.add("Zone", "Office", {"x_origin": 0.0})
+        sim_proc = MagicMock(returncode=0, stdout="ok", stderr="")
+        job = SimulationJob(model=slab_model, weather=weather_file, preprocessor_timeout=180.0)
+
+        with (
+            patch("idfkit.simulation.expand.run_preprocessing", return_value=preprocessed) as mock_pp,
+            patch("idfkit.simulation.runner.subprocess.run", return_value=sim_proc),
+        ):
+            simulate_batch([job], energyplus=mock_config, max_workers=1)
+
+        assert mock_pp.call_args.kwargs["timeout"] == 180.0


### PR DESCRIPTION
## Summary

Adds a new `preprocessor_timeout` parameter to control subprocess timeouts for the ExpandObjects, Slab, and Basement preprocessors that run automatically during simulation. This allows users to handle slow shared hardware or fail fast in CI environments.

## Key Changes

- **New `resolve_preprocessor_timeout()` helper** in `_common.py` that implements a three-tier resolution strategy:
  1. Explicit caller-supplied value (highest priority)
  2. `IDFKIT_PREPROCESSOR_TIMEOUT` environment variable
  3. Default of 120 seconds (lowest priority)

- **Added `preprocessor_timeout` parameter** to:
  - `simulate()` and `async_simulate()` entry points
  - `SimulationJob` dataclass for batch operations
  - `maybe_preprocess()` internal function

- **Environment variable support**: `IDFKIT_PREPROCESSOR_TIMEOUT` allows process-wide configuration with validation (must be a positive number)

- **Independent timeout budgets**: The preprocessor timeout is completely separate from the main EnergyPlus `timeout` parameter — each preprocessor stage gets its own fresh window, and there is no shared wall-clock cap across the pipeline

- **Comprehensive test coverage** with 219 lines of tests covering:
  - Resolution logic with explicit values, env vars, and defaults
  - Error handling for invalid/non-positive env var values
  - Forwarding through `simulate()`, `async_simulate()`, and batch APIs

- **Documentation updates** covering:
  - New parameter in API docs for `simulate()`, `async_simulate()`, and `SimulationJob`
  - Dedicated "Preprocessor Timeout" section in running.md with examples
  - Environment variable documentation in concepts/environment-variables.md
  - Notes in async.md and batch.md about preprocessor timeout support

## Implementation Details

- The timeout is applied per-subprocess invocation, not as a shared budget
- Invalid environment variable values raise `ValueError` at simulation time (not at import time)
- Explicit parameter values bypass environment variable parsing entirely
- Batch operations forward per-job `preprocessor_timeout` values through to the underlying `simulate()` calls

https://claude.ai/code/session_0141WjecwC2NQNppJ85pPmew