### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog 1.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,24 @@ uv run ruff check src/ tests/
 uv run ruff format src/ tests/
 ```
 
+## Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
+and is the source of truth for release notes. Update it in the same change that
+introduces user-visible behavior — new public API, behavior changes, breaking
+renames, bug fixes, performance changes worth flagging, or security fixes. Skip
+purely internal refactors, CI tweaks, lockfile bumps, and doc-site styling.
+
+Add new entries under `## [Unreleased]` at the top of the file, in the
+appropriate `### Added / Changed / Deprecated / Removed / Fixed / Security`
+subsection. Surface breaking changes inline with a `**Breaking:**` prefix; do
+not invent new categories. Write entries for humans, in past tense, ending with
+a period — not as commit messages.
+
+At release time the `[Unreleased]` heading is renamed to `[X.Y.Z] - YYYY-MM-DD`,
+a fresh empty `[Unreleased]` section is added above it, and the compare-link
+definitions at the bottom are updated.
+
 ## Code Conventions
 
 - Every module starts with `from __future__ import annotations`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ subsection. Surface breaking changes inline with a `**Breaking:**` prefix; do
 not invent new categories. Write entries for humans, in past tense, ending with
 a period — not as commit messages.
 
+End each entry with a parenthetical link to the PR
+(`([#152](https://github.com/idfkit/idfkit/pull/152))`) or, when the change
+landed without a PR, the short commit SHA
+(`([f973e60](https://github.com/idfkit/idfkit/commit/f973e60))`).
+
 At release time the `[Unreleased]` heading is renamed to `[X.Y.Z] - YYYY-MM-DD`,
 a fresh empty `[Unreleased]` section is added above it, and the compare-link
 definitions at the bottom are updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,263 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.12.0] - 2026-05-05
+
+### Added
+
+- `simulate()` now forwards a `preprocessor_timeout` parameter to ExpandObjects, Slab, and Basement runs.
+
+### Changed
+
+- IDFObject field reads are roughly 4x faster and field writes ~43% faster after hot-path slimming and `to_python_name` caching.
+- IDFCollection string lookups are faster: string keys now bypass the type-check branch in `__getitem__`.
+
+## [0.11.1] - 2026-04-28
+
+### Fixed
+
+- `IDFObject.copy()` now preserves `wrapper_key` and `ext_inner_names`, so copies of objects with extensible arrays round-trip correctly.
+
+## [0.11.0] - 2026-04-28
+
+### Added
+
+- Selective ZIP extraction in weather downloads via a new `only=` parameter on `download()`, so callers can pull just the EPW or DDY without unpacking the whole archive.
+
+### Changed
+
+- Typing improvements across the public API: `write_idf` / `write_epjson` overloads, `IDFCollection.get` overload, `TimeSeriesResult.to_dataframe()` annotated as `pd.DataFrame`, and `TimeSeriesResult.plot` backend parameter narrowed.
+
+## [0.10.3] - 2026-04-27
+
+### Changed
+
+- `IDFDocument.add()` now emits a `DeprecationWarning` when it has to rewrite flat-extensible kwargs into the canonical array form. Callers should pass extensibles using the canonical API.
+
+## [0.10.2] - 2026-04-27
+
+### Fixed
+
+- `FieldDescription.field_type` now preserves `anyOf` unions from the schema instead of collapsing them, so introspection of polymorphic fields is accurate.
+
+## [0.10.1] - 2026-04-27
+
+### Fixed
+
+- Weather station index now falls back to the bundled index when the user cache was written by an older schema version, instead of failing on load.
+
+## [0.10.0] - 2026-04-27
+
+### Added
+
+- Canonical extensible-array storage and access API. Extensible groups are now read and written as arrays through a stable interface rather than via flat indexed kwargs.
+- `idfkit tmy --nearby` auto-detects the user's location from IP and finds the closest TMY stations.
+- Throttled freshness check for the weather station index, so the bundled index is updated when stale without nagging on every run.
+- Environment variables reference page in the documentation.
+- Richer station filters and a mobile-friendly layout in the TMY browser.
+- Docstrings are now threaded into generated type stubs.
+
+### Changed
+
+- **Breaking:** `IDFDocument.add()`'s `data=` kwarg has been renamed to `fields=`. Update call sites accordingly.
+- Weather station index switched from Excel to KML format and now carries climate-zone metadata. The optional `[weather]` extra is no longer required for the bundled index to work — references to it have been removed from the docs.
+- `doc["Type"]` access path was reworked alongside the canonical extensible API; behavior is preserved but the underlying storage is different.
+
+## [0.9.0] - 2026-04-21
+
+### Added
+
+- `idfkit tmy` CLI subcommand for fetching TMYx weather data, with VHS tape recordings in the docs.
+
+## [0.8.0] - 2026-04-16
+
+### Added
+
+- EnergyPlus 26.1.0 schema is now bundled and supported.
+- `idfkit migrate` CLI subcommand for IDF version migration from the command line.
+
+## [0.7.1] - 2026-04-16
+
+### Fixed
+
+- Concurrent migrations no longer collide on `audit.out`: each migration step runs in its own isolated CWD.
+
+## [0.7.0] - 2026-04-15
+
+### Added
+
+- IDF version migration with both synchronous and asynchronous orchestrators, so models can be upgraded across EnergyPlus versions programmatically.
+
+## [0.6.5] - 2026-04-03
+
+### Added
+
+- Windows drive root is now consulted by EnergyPlus auto-discovery, so installs at `C:\EnergyPlusV*` are found without manual configuration.
+
+### Changed
+
+- Project test coverage raised to ~100% across schedules, weather, simulation, parsers, document/schema, validation, introspection, exceptions, geometry, codegen, visualization, and the eppy compatibility layer. No user-visible API change, but the regression surface is now substantially smaller.
+
+## [0.6.4] - 2026-03-31
+
+### Fixed
+
+- Four bugs surfaced by stress testing across the parser and document layers.
+- `Version` is now normalized as a regular collection entry rather than a special-cased object, fixing inconsistencies in iteration and lookup.
+
+## [0.6.3] - 2026-03-27
+
+### Changed
+
+- Public API surface of the `objects` module has been tightened — internal helpers no longer leak as importable names.
+- Extensible field names are now normalized to the epJSON schema convention.
+
+### Fixed
+
+- Extensible field handling: `field_order` is maintained correctly across mutations, and schedule parsing no longer mishandles extensible groups.
+- Various dead URLs across the project documentation.
+
+## [0.6.2] - 2026-03-26
+
+### Added
+
+- `IDFCollection` now supports retrieval of unnamed/singleton objects.
+
+## [0.6.1] - 2026-03-26
+
+### Fixed
+
+- Extensible field introspection and reference detection now work correctly.
+
+## [0.6.0] - 2026-03-25
+
+### Changed
+
+- **Breaking:** Strict field access is now the default — accessing an unknown field raises instead of returning `None`. Pass `strict=False` to opt out where the previous behavior is needed.
+- **Breaking:** `strict` parameters were renamed across the API for consistency. Review call sites that pass strict-mode flags.
+- Exception hierarchy now inherits from a common `IdfKitError` base and includes documentation URLs pointing at the relevant concept page.
+- CST scanner optimized with regex; extensible field handling sped up.
+
+### Added
+
+- Documentation URL builder module that backs the new exception messages.
+- PR doc preview comments now link to the changed pages.
+
+### Fixed
+
+- IDF type name resolution is now case-insensitive, matching EnergyPlus's own behavior.
+- `set_wwr` now preserves construction names and cross-references on the rebuilt fenestration.
+
+## [0.5.0] - 2026-03-14
+
+### Added
+
+- `new_document()` accepts a `strict` parameter to control field-access strictness up-front.
+- Type-safety and performance improvements for `IDFDocument` and stub generation.
+
+### Changed
+
+- Renamed the experiment parameter from `experiment` to `runnable` in batch APIs.
+
+### Fixed
+
+- `get_surface_coords` no longer crashes when `number_of_vertices` is blank.
+
+## [0.4.0] - 2026-03-03
+
+### Added
+
+- Weather search and direct download by EPW filename, in addition to lookup by station ID and coordinates.
+- Block stacking with `base_elevation` and horizontal adjacency linking, for assembling multi-block models programmatically.
+
+## [0.3.1] - 2026-03-02
+
+### Fixed
+
+- Strict IDF parser now raises informative errors on malformed input instead of failing partway through with unrelated tracebacks.
+
+## [0.3.0] - 2026-02-26
+
+### Added
+
+- EnergyPlus version compatibility checker for Python files (used to validate that snippets and user code target a supported version).
+- `validate_document` and `new_document` now seed and enforce schema singleton uniqueness via `maxProperties`.
+- Enhanced extensible-object handling in `IDFDocument` and introspection.
+
+## [0.2.0] - 2026-02-20
+
+### Added
+
+- Comprehensive logging throughout idfkit modules — every parser, simulation, and weather subsystem now logs at consistent levels.
+- User documentation for the `create_building` API and the zoning module.
+
+### Changed
+
+- IDF/epJSON loading is approximately 2.4x faster via per-type parsing cache.
+- Lookup of all objects of a given type is approximately 60x faster: `__getitem__` now uses a single dict lookup instead of scanning.
+
+## [0.1.1] - 2026-02-12
+
+### Added
+
+- Comprehensive eppy compatibility layer (`idfkit._compat`) and additional geometry operations, easing migration from eppy.
+- `AsyncFileSystem` protocol so async simulation pipelines no longer block the event loop on filesystem I/O.
+- Documentation tutorials for using idfkit with [Scythe](https://github.com/anthropics/scythe) distributed experiments and Celery.
+
+### Fixed
+
+- Tutorial bugs surfaced during end-to-end cloud simulation testing.
+- HTML result detection in the simulation result parser.
+
+## [0.1.0] - 2026-02-11
+
+Initial public release.
+
+### Added
+
+- IDF and epJSON parser, writer, and round-trip support.
+- `IDFDocument`, `IDFObject`, and name-indexed `IDFCollection` core data model with O(1) lookups.
+- `ReferenceGraph` that tracks cross-object references and updates automatically on rename.
+- Schema-driven validation against bundled epJSON schemas.
+- Bundled schemas covering EnergyPlus 8.9.0 through 25.2.0.
+- EnergyPlus simulation execution: synchronous, asynchronous (`async_simulate`), and batch runners with content-addressed result caching.
+- Preprocessor support for `ExpandObjects`, `Slab`, and `Basement`.
+- Result parsers for SQL, CSV, ERR, RDD, and HTML outputs.
+- Weather module: ~17k-station search index, EPW/DDY download with local cache, design-day injection, and Nominatim-backed geocoding.
+- Schedule evaluation engine covering all eight EnergyPlus schedule types, usable without running a simulation.
+- Thermal property calculations: R/U-values, SHGC, gas mixture properties.
+- 3D building geometry visualization with SVG output, including dark-mode support.
+- Performance benchmarks comparing idfkit against eppy and opyplus.
+- MkDocs Material documentation site with a full API reference, an eppy migration guide, and a getting-started Jupyter notebook.
+
+[unreleased]: https://github.com/idfkit/idfkit/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/idfkit/idfkit/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/idfkit/idfkit/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/idfkit/idfkit/compare/v0.10.3...v0.11.0
+[0.10.3]: https://github.com/idfkit/idfkit/compare/v0.10.2...v0.10.3
+[0.10.2]: https://github.com/idfkit/idfkit/compare/0.10.1...v0.10.2
+[0.10.1]: https://github.com/idfkit/idfkit/compare/0.10.0...0.10.1
+[0.10.0]: https://github.com/idfkit/idfkit/compare/0.9.0...0.10.0
+[0.9.0]: https://github.com/idfkit/idfkit/compare/0.8.0...0.9.0
+[0.8.0]: https://github.com/idfkit/idfkit/compare/0.7.1...0.8.0
+[0.7.1]: https://github.com/idfkit/idfkit/compare/0.7.0...0.7.1
+[0.7.0]: https://github.com/idfkit/idfkit/compare/0.6.5...0.7.0
+[0.6.5]: https://github.com/idfkit/idfkit/compare/v0.6.4...0.6.5
+[0.6.4]: https://github.com/idfkit/idfkit/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/idfkit/idfkit/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/idfkit/idfkit/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/idfkit/idfkit/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/idfkit/idfkit/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/idfkit/idfkit/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/idfkit/idfkit/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/idfkit/idfkit/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/idfkit/idfkit/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/idfkit/idfkit/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/idfkit/idfkit/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/idfkit/idfkit/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,209 +11,210 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `simulate()` now forwards a `preprocessor_timeout` parameter to ExpandObjects, Slab, and Basement runs.
+- `simulate()` now forwards a `preprocessor_timeout` parameter to ExpandObjects, Slab, and Basement runs. ([#152](https://github.com/idfkit/idfkit/pull/152))
 
 ### Changed
 
-- IDFObject field reads are roughly 4x faster and field writes ~43% faster after hot-path slimming and `to_python_name` caching.
-- IDFCollection string lookups are faster: string keys now bypass the type-check branch in `__getitem__`.
+- IDFObject field reads are roughly 4x faster after hot-path slimming. ([f973e60](https://github.com/idfkit/idfkit/commit/f973e60))
+- IDFObject field writes are ~43% faster via `to_python_name` caching. ([e76f83e](https://github.com/idfkit/idfkit/commit/e76f83e))
+- IDFCollection string lookups are faster: string keys now bypass the type-check branch in `__getitem__`. ([4bde898](https://github.com/idfkit/idfkit/commit/4bde898))
 
 ## [0.11.1] - 2026-04-28
 
 ### Fixed
 
-- `IDFObject.copy()` now preserves `wrapper_key` and `ext_inner_names`, so copies of objects with extensible arrays round-trip correctly.
+- `IDFObject.copy()` now preserves `wrapper_key` and `ext_inner_names`, so copies of objects with extensible arrays round-trip correctly. ([#150](https://github.com/idfkit/idfkit/pull/150))
 
 ## [0.11.0] - 2026-04-28
 
 ### Added
 
-- Selective ZIP extraction in weather downloads via a new `only=` parameter on `download()`, so callers can pull just the EPW or DDY without unpacking the whole archive.
+- Selective ZIP extraction in weather downloads via a new `only=` parameter on `download()`, so callers can pull just the EPW or DDY without unpacking the whole archive. ([#144](https://github.com/idfkit/idfkit/pull/144))
 
 ### Changed
 
-- Typing improvements across the public API: `write_idf` / `write_epjson` overloads, `IDFCollection.get` overload, `TimeSeriesResult.to_dataframe()` annotated as `pd.DataFrame`, and `TimeSeriesResult.plot` backend parameter narrowed.
+- Typing improvements across the public API: `write_idf` / `write_epjson` overloads ([#145](https://github.com/idfkit/idfkit/pull/145)), `IDFCollection.get` overload ([#146](https://github.com/idfkit/idfkit/pull/146)), `TimeSeriesResult.to_dataframe()` annotated as `pd.DataFrame` ([#147](https://github.com/idfkit/idfkit/pull/147)), and `TimeSeriesResult.plot` backend parameter narrowed ([#148](https://github.com/idfkit/idfkit/pull/148)).
 
 ## [0.10.3] - 2026-04-27
 
 ### Changed
 
-- `IDFDocument.add()` now emits a `DeprecationWarning` when it has to rewrite flat-extensible kwargs into the canonical array form. Callers should pass extensibles using the canonical API.
+- `IDFDocument.add()` now emits a `DeprecationWarning` when it has to rewrite flat-extensible kwargs into the canonical array form. Callers should pass extensibles using the canonical API. ([#143](https://github.com/idfkit/idfkit/pull/143))
 
 ## [0.10.2] - 2026-04-27
 
 ### Fixed
 
-- `FieldDescription.field_type` now preserves `anyOf` unions from the schema instead of collapsing them, so introspection of polymorphic fields is accurate.
+- `FieldDescription.field_type` now preserves `anyOf` unions from the schema instead of collapsing them, so introspection of polymorphic fields is accurate. ([#142](https://github.com/idfkit/idfkit/pull/142))
 
 ## [0.10.1] - 2026-04-27
 
 ### Fixed
 
-- Weather station index now falls back to the bundled index when the user cache was written by an older schema version, instead of failing on load.
+- Weather station index now falls back to the bundled index when the user cache was written by an older schema version, instead of failing on load. ([dcde4b7](https://github.com/idfkit/idfkit/commit/dcde4b7))
 
 ## [0.10.0] - 2026-04-27
 
 ### Added
 
-- Canonical extensible-array storage and access API. Extensible groups are now read and written as arrays through a stable interface rather than via flat indexed kwargs.
-- `idfkit tmy --nearby` auto-detects the user's location from IP and finds the closest TMY stations.
-- Throttled freshness check for the weather station index, so the bundled index is updated when stale without nagging on every run.
-- Environment variables reference page in the documentation.
-- Richer station filters and a mobile-friendly layout in the TMY browser.
-- Docstrings are now threaded into generated type stubs.
+- Canonical extensible-array storage and access API. Extensible groups are now read and written as arrays through a stable interface rather than via flat indexed kwargs. ([#140](https://github.com/idfkit/idfkit/pull/140))
+- `idfkit tmy --nearby` auto-detects the user's location from IP and finds the closest TMY stations. ([#134](https://github.com/idfkit/idfkit/pull/134))
+- Throttled freshness check for the weather station index, so the bundled index is updated when stale without nagging on every run. ([#137](https://github.com/idfkit/idfkit/pull/137))
+- Environment variables reference page in the documentation. ([#138](https://github.com/idfkit/idfkit/pull/138))
+- Richer station filters and a mobile-friendly layout in the TMY browser. ([#139](https://github.com/idfkit/idfkit/pull/139))
+- Docstrings are now threaded into generated type stubs. ([#141](https://github.com/idfkit/idfkit/pull/141))
 
 ### Changed
 
-- **Breaking:** `IDFDocument.add()`'s `data=` kwarg has been renamed to `fields=`. Update call sites accordingly.
-- Weather station index switched from Excel to KML format and now carries climate-zone metadata. The optional `[weather]` extra is no longer required for the bundled index to work — references to it have been removed from the docs.
-- `doc["Type"]` access path was reworked alongside the canonical extensible API; behavior is preserved but the underlying storage is different.
+- **Breaking:** `IDFDocument.add()`'s `data=` kwarg has been renamed to `fields=`. Update call sites accordingly. ([28c742d](https://github.com/idfkit/idfkit/commit/28c742d))
+- Weather station index switched from Excel to KML format and now carries climate-zone metadata. The optional `[weather]` extra is no longer required for the bundled index to work — references to it have been removed from the docs. ([#136](https://github.com/idfkit/idfkit/pull/136), [4499c5c](https://github.com/idfkit/idfkit/commit/4499c5c))
+- `doc["Type"]` access path was reworked alongside the canonical extensible API; behavior is preserved but the underlying storage is different. ([#141](https://github.com/idfkit/idfkit/pull/141))
 
 ## [0.9.0] - 2026-04-21
 
 ### Added
 
-- `idfkit tmy` CLI subcommand for fetching TMYx weather data, with VHS tape recordings in the docs.
+- `idfkit tmy` CLI subcommand for fetching TMYx weather data, with VHS tape recordings in the docs. ([#132](https://github.com/idfkit/idfkit/pull/132), [#133](https://github.com/idfkit/idfkit/pull/133))
 
 ## [0.8.0] - 2026-04-16
 
 ### Added
 
-- EnergyPlus 26.1.0 schema is now bundled and supported.
-- `idfkit migrate` CLI subcommand for IDF version migration from the command line.
+- EnergyPlus 26.1.0 schema is now bundled and supported. ([6060742](https://github.com/idfkit/idfkit/commit/6060742))
+- `idfkit migrate` CLI subcommand for IDF version migration from the command line. ([#131](https://github.com/idfkit/idfkit/pull/131))
 
 ## [0.7.1] - 2026-04-16
 
 ### Fixed
 
-- Concurrent migrations no longer collide on `audit.out`: each migration step runs in its own isolated CWD.
+- Concurrent migrations no longer collide on `audit.out`: each migration step runs in its own isolated CWD. ([#130](https://github.com/idfkit/idfkit/pull/130))
 
 ## [0.7.0] - 2026-04-15
 
 ### Added
 
-- IDF version migration with both synchronous and asynchronous orchestrators, so models can be upgraded across EnergyPlus versions programmatically.
+- IDF version migration with both synchronous and asynchronous orchestrators, so models can be upgraded across EnergyPlus versions programmatically. ([#128](https://github.com/idfkit/idfkit/pull/128))
 
 ## [0.6.5] - 2026-04-03
 
 ### Added
 
-- Windows drive root is now consulted by EnergyPlus auto-discovery, so installs at `C:\EnergyPlusV*` are found without manual configuration.
+- Windows drive root is now consulted by EnergyPlus auto-discovery, so installs at `C:\EnergyPlusV*` are found without manual configuration. ([#122](https://github.com/idfkit/idfkit/pull/122))
 
 ### Changed
 
-- Project test coverage raised to ~100% across schedules, weather, simulation, parsers, document/schema, validation, introspection, exceptions, geometry, codegen, visualization, and the eppy compatibility layer. No user-visible API change, but the regression surface is now substantially smaller.
+- Project test coverage raised to ~100% across schedules, weather, simulation, parsers, document/schema, validation, introspection, exceptions, geometry, codegen, visualization, and the eppy compatibility layer. No user-visible API change, but the regression surface is now substantially smaller. ([#100](https://github.com/idfkit/idfkit/pull/100), [#101](https://github.com/idfkit/idfkit/pull/101), [#102](https://github.com/idfkit/idfkit/pull/102), [#103](https://github.com/idfkit/idfkit/pull/103), [#104](https://github.com/idfkit/idfkit/pull/104), [#105](https://github.com/idfkit/idfkit/pull/105), [#106](https://github.com/idfkit/idfkit/pull/106), [#110](https://github.com/idfkit/idfkit/pull/110), [#111](https://github.com/idfkit/idfkit/pull/111), [#112](https://github.com/idfkit/idfkit/pull/112), [#113](https://github.com/idfkit/idfkit/pull/113), [#114](https://github.com/idfkit/idfkit/pull/114), [#115](https://github.com/idfkit/idfkit/pull/115), [#116](https://github.com/idfkit/idfkit/pull/116), [#117](https://github.com/idfkit/idfkit/pull/117), [#118](https://github.com/idfkit/idfkit/pull/118))
 
 ## [0.6.4] - 2026-03-31
 
 ### Fixed
 
-- Four bugs surfaced by stress testing across the parser and document layers.
-- `Version` is now normalized as a regular collection entry rather than a special-cased object, fixing inconsistencies in iteration and lookup.
+- Four bugs surfaced by stress testing across the parser and document layers. ([#99](https://github.com/idfkit/idfkit/pull/99))
+- `Version` is now normalized as a regular collection entry rather than a special-cased object, fixing inconsistencies in iteration and lookup. ([#119](https://github.com/idfkit/idfkit/pull/119), [#120](https://github.com/idfkit/idfkit/pull/120))
 
 ## [0.6.3] - 2026-03-27
 
 ### Changed
 
-- Public API surface of the `objects` module has been tightened — internal helpers no longer leak as importable names.
-- Extensible field names are now normalized to the epJSON schema convention.
+- Public API surface of the `objects` module has been tightened — internal helpers no longer leak as importable names. ([#98](https://github.com/idfkit/idfkit/pull/98))
+- Extensible field names are now normalized to the epJSON schema convention. ([#97](https://github.com/idfkit/idfkit/pull/97))
 
 ### Fixed
 
-- Extensible field handling: `field_order` is maintained correctly across mutations, and schedule parsing no longer mishandles extensible groups.
-- Various dead URLs across the project documentation.
+- Extensible field handling: `field_order` is maintained correctly across mutations, and schedule parsing no longer mishandles extensible groups. ([#96](https://github.com/idfkit/idfkit/pull/96))
+- Various dead URLs across the project documentation. ([#84](https://github.com/idfkit/idfkit/pull/84))
 
 ## [0.6.2] - 2026-03-26
 
 ### Added
 
-- `IDFCollection` now supports retrieval of unnamed/singleton objects.
+- `IDFCollection` now supports retrieval of unnamed/singleton objects. ([#94](https://github.com/idfkit/idfkit/pull/94))
 
 ## [0.6.1] - 2026-03-26
 
 ### Fixed
 
-- Extensible field introspection and reference detection now work correctly.
+- Extensible field introspection and reference detection now work correctly. ([#92](https://github.com/idfkit/idfkit/pull/92), [#93](https://github.com/idfkit/idfkit/pull/93))
 
 ## [0.6.0] - 2026-03-25
 
 ### Changed
 
-- **Breaking:** Strict field access is now the default — accessing an unknown field raises instead of returning `None`. Pass `strict=False` to opt out where the previous behavior is needed.
-- **Breaking:** `strict` parameters were renamed across the API for consistency. Review call sites that pass strict-mode flags.
-- Exception hierarchy now inherits from a common `IdfKitError` base and includes documentation URLs pointing at the relevant concept page.
-- CST scanner optimized with regex; extensible field handling sped up.
+- **Breaking:** Strict field access is now the default — accessing an unknown field raises instead of returning `None`. Pass `strict=False` to opt out where the previous behavior is needed. ([#91](https://github.com/idfkit/idfkit/pull/91))
+- **Breaking:** `strict` parameters were renamed across the API for consistency. Review call sites that pass strict-mode flags. ([#90](https://github.com/idfkit/idfkit/pull/90))
+- Exception hierarchy now inherits from a common `IdfKitError` base and includes documentation URLs pointing at the relevant concept page. ([#89](https://github.com/idfkit/idfkit/pull/89))
+- CST scanner optimized with regex; extensible field handling sped up. ([#82](https://github.com/idfkit/idfkit/pull/82))
 
 ### Added
 
-- Documentation URL builder module that backs the new exception messages.
-- PR doc preview comments now link to the changed pages.
+- Documentation URL builder module that backs the new exception messages. ([#85](https://github.com/idfkit/idfkit/pull/85))
+- PR doc preview comments now link to the changed pages. ([#83](https://github.com/idfkit/idfkit/pull/83))
 
 ### Fixed
 
-- IDF type name resolution is now case-insensitive, matching EnergyPlus's own behavior.
-- `set_wwr` now preserves construction names and cross-references on the rebuilt fenestration.
+- IDF type name resolution is now case-insensitive, matching EnergyPlus's own behavior. ([#81](https://github.com/idfkit/idfkit/pull/81))
+- `set_wwr` now preserves construction names and cross-references on the rebuilt fenestration. ([#80](https://github.com/idfkit/idfkit/pull/80))
 
 ## [0.5.0] - 2026-03-14
 
 ### Added
 
-- `new_document()` accepts a `strict` parameter to control field-access strictness up-front.
-- Type-safety and performance improvements for `IDFDocument` and stub generation.
+- `new_document()` accepts a `strict` parameter to control field-access strictness up-front. ([#74](https://github.com/idfkit/idfkit/pull/74))
+- Type-safety and performance improvements for `IDFDocument` and stub generation. ([#75](https://github.com/idfkit/idfkit/pull/75))
 
 ### Changed
 
-- Renamed the experiment parameter from `experiment` to `runnable` in batch APIs.
+- Renamed the experiment parameter from `experiment` to `runnable` in batch APIs. ([#73](https://github.com/idfkit/idfkit/pull/73))
 
 ### Fixed
 
-- `get_surface_coords` no longer crashes when `number_of_vertices` is blank.
+- `get_surface_coords` no longer crashes when `number_of_vertices` is blank. ([#78](https://github.com/idfkit/idfkit/pull/78))
 
 ## [0.4.0] - 2026-03-03
 
 ### Added
 
-- Weather search and direct download by EPW filename, in addition to lookup by station ID and coordinates.
-- Block stacking with `base_elevation` and horizontal adjacency linking, for assembling multi-block models programmatically.
+- Weather search and direct download by EPW filename, in addition to lookup by station ID and coordinates. ([#69](https://github.com/idfkit/idfkit/pull/69))
+- Block stacking with `base_elevation` and horizontal adjacency linking, for assembling multi-block models programmatically. ([#67](https://github.com/idfkit/idfkit/pull/67))
 
 ## [0.3.1] - 2026-03-02
 
 ### Fixed
 
-- Strict IDF parser now raises informative errors on malformed input instead of failing partway through with unrelated tracebacks.
+- Strict IDF parser now raises informative errors on malformed input instead of failing partway through with unrelated tracebacks. ([#64](https://github.com/idfkit/idfkit/pull/64))
 
 ## [0.3.0] - 2026-02-26
 
 ### Added
 
-- EnergyPlus version compatibility checker for Python files (used to validate that snippets and user code target a supported version).
-- `validate_document` and `new_document` now seed and enforce schema singleton uniqueness via `maxProperties`.
-- Enhanced extensible-object handling in `IDFDocument` and introspection.
+- EnergyPlus version compatibility checker for Python files (used to validate that snippets and user code target a supported version). ([#59](https://github.com/idfkit/idfkit/pull/59))
+- `validate_document` and `new_document` now seed and enforce schema singleton uniqueness via `maxProperties`. ([#58](https://github.com/idfkit/idfkit/pull/58), [#60](https://github.com/idfkit/idfkit/pull/60), [#61](https://github.com/idfkit/idfkit/pull/61))
+- Enhanced extensible-object handling in `IDFDocument` and introspection. ([#57](https://github.com/idfkit/idfkit/pull/57))
 
 ## [0.2.0] - 2026-02-20
 
 ### Added
 
-- Comprehensive logging throughout idfkit modules — every parser, simulation, and weather subsystem now logs at consistent levels.
-- User documentation for the `create_building` API and the zoning module.
+- Comprehensive logging throughout idfkit modules — every parser, simulation, and weather subsystem now logs at consistent levels. ([#53](https://github.com/idfkit/idfkit/pull/53))
+- User documentation for the `create_building` API and the zoning module. ([#52](https://github.com/idfkit/idfkit/pull/52))
 
 ### Changed
 
-- IDF/epJSON loading is approximately 2.4x faster via per-type parsing cache.
-- Lookup of all objects of a given type is approximately 60x faster: `__getitem__` now uses a single dict lookup instead of scanning.
+- IDF/epJSON loading is approximately 2.4x faster via per-type parsing cache. ([18e620e](https://github.com/idfkit/idfkit/commit/18e620e))
+- Lookup of all objects of a given type is approximately 60x faster: `__getitem__` now uses a single dict lookup instead of scanning. ([568e2d5](https://github.com/idfkit/idfkit/commit/568e2d5))
 
 ## [0.1.1] - 2026-02-12
 
 ### Added
 
-- Comprehensive eppy compatibility layer (`idfkit._compat`) and additional geometry operations, easing migration from eppy.
-- `AsyncFileSystem` protocol so async simulation pipelines no longer block the event loop on filesystem I/O.
-- Documentation tutorials for using idfkit with [Scythe](https://github.com/anthropics/scythe) distributed experiments and Celery.
+- Comprehensive eppy compatibility layer (`idfkit._compat`) and additional geometry operations, easing migration from eppy. ([#46](https://github.com/idfkit/idfkit/pull/46))
+- `AsyncFileSystem` protocol so async simulation pipelines no longer block the event loop on filesystem I/O. ([#40](https://github.com/idfkit/idfkit/pull/40))
+- Documentation tutorials for using idfkit with Scythe distributed experiments and Celery. ([#42](https://github.com/idfkit/idfkit/pull/42), [#43](https://github.com/idfkit/idfkit/pull/43))
 
 ### Fixed
 
-- Tutorial bugs surfaced during end-to-end cloud simulation testing.
-- HTML result detection in the simulation result parser.
+- Tutorial bugs surfaced during end-to-end cloud simulation testing. ([#45](https://github.com/idfkit/idfkit/pull/45), [#47](https://github.com/idfkit/idfkit/pull/47))
+- HTML result detection in the simulation result parser. ([#47](https://github.com/idfkit/idfkit/pull/47))
 
 ## [0.1.0] - 2026-02-11
 
@@ -222,19 +223,19 @@ Initial public release.
 ### Added
 
 - IDF and epJSON parser, writer, and round-trip support.
-- `IDFDocument`, `IDFObject`, and name-indexed `IDFCollection` core data model with O(1) lookups.
+- `IDFDocument`, `IDFObject`, and name-indexed `IDFCollection` core data model with O(1) lookups. ([#3](https://github.com/idfkit/idfkit/pull/3))
 - `ReferenceGraph` that tracks cross-object references and updates automatically on rename.
 - Schema-driven validation against bundled epJSON schemas.
-- Bundled schemas covering EnergyPlus 8.9.0 through 25.2.0.
-- EnergyPlus simulation execution: synchronous, asynchronous (`async_simulate`), and batch runners with content-addressed result caching.
-- Preprocessor support for `ExpandObjects`, `Slab`, and `Basement`.
-- Result parsers for SQL, CSV, ERR, RDD, and HTML outputs.
-- Weather module: ~17k-station search index, EPW/DDY download with local cache, design-day injection, and Nominatim-backed geocoding.
+- Bundled schemas covering EnergyPlus 8.9.0 through 25.2.0. ([#4](https://github.com/idfkit/idfkit/pull/4))
+- EnergyPlus simulation execution: synchronous, asynchronous (`async_simulate`), and batch runners with content-addressed result caching. ([#10](https://github.com/idfkit/idfkit/pull/10), [#17](https://github.com/idfkit/idfkit/pull/17))
+- Preprocessor support for `ExpandObjects`, `Slab`, and `Basement`. ([#15](https://github.com/idfkit/idfkit/pull/15))
+- Simulation progress callbacks. ([#18](https://github.com/idfkit/idfkit/pull/18))
+- Weather module: ~17k-station search index, EPW/DDY download with local cache, design-day injection, and Nominatim-backed geocoding. ([#8](https://github.com/idfkit/idfkit/pull/8))
 - Schedule evaluation engine covering all eight EnergyPlus schedule types, usable without running a simulation.
 - Thermal property calculations: R/U-values, SHGC, gas mixture properties.
-- 3D building geometry visualization with SVG output, including dark-mode support.
-- Performance benchmarks comparing idfkit against eppy and opyplus.
-- MkDocs Material documentation site with a full API reference, an eppy migration guide, and a getting-started Jupyter notebook.
+- 3D building geometry visualization with SVG output, including dark-mode support. ([#13](https://github.com/idfkit/idfkit/pull/13))
+- Performance benchmarks comparing idfkit against eppy and opyplus. ([#5](https://github.com/idfkit/idfkit/pull/5))
+- MkDocs Material documentation site with a full API reference, an eppy migration guide, and a getting-started Jupyter notebook. ([#2](https://github.com/idfkit/idfkit/pull/2))
 
 [unreleased]: https://github.com/idfkit/idfkit/compare/v0.12.0...HEAD
 [0.12.0]: https://github.com/idfkit/idfkit/compare/v0.11.1...v0.12.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,12 @@ Security` subsection. Surface breaking changes inline with a `**Breaking:**`
 prefix; do not invent new categories. Write entries for humans, in past tense,
 ending with a period — not as commit messages.
 
+**Reference the source.** End each entry with a parenthetical link to the PR
+(`([#152](https://github.com/idfkit/idfkit/pull/152))`) or, when the change
+landed without a PR, the short commit SHA
+(`([f973e60](https://github.com/idfkit/idfkit/commit/f973e60))`). Multiple
+refs go in one parenthetical, comma-separated.
+
 **At release time:** rename the `[Unreleased]` heading to `[X.Y.Z] - YYYY-MM-DD`,
 add a fresh empty `[Unreleased]` section above it, and update the compare-link
 definitions at the bottom of the file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,27 @@ Every variable that command surfaces should appear in the docs page.
 
 Bundled schemas cover EnergyPlus 8.9.0 through 26.1.0 (17 versions). The latest supported version is 26.1.0. Version 24.1.0 is used as the default in test fixtures. See `src/idfkit/versions.py` for the full list.
 
+## Changelog
+
+`CHANGELOG.md` follows the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
+convention and is the source of truth for release notes. Keep it up to date as
+part of the same change that introduces a user-visible behavior.
+
+**When to update it:** any PR that adds, changes, deprecates, removes, or fixes
+something a user would notice — new public API, behavior changes, breaking
+renames, bug fixes, performance changes worth flagging, security fixes. Skip it
+for purely internal refactors, CI tweaks, lockfile bumps, and doc-site styling.
+
+**Where to put new entries:** under the `## [Unreleased]` section at the top,
+in the appropriate `### Added / Changed / Deprecated / Removed / Fixed /
+Security` subsection. Surface breaking changes inline with a `**Breaking:**`
+prefix; do not invent new categories. Write entries for humans, in past tense,
+ending with a period — not as commit messages.
+
+**At release time:** rename the `[Unreleased]` heading to `[X.Y.Z] - YYYY-MM-DD`,
+add a fresh empty `[Unreleased]` section above it, and update the compare-link
+definitions at the bottom of the file.
+
 ## Releases
 
 Releases are GitHub-Release-driven: creating a published Release on `main`
@@ -210,6 +231,9 @@ the source of truth — the git tag is. Do not bump it in a separate commit.
 through `0.10.1` was cut without the prefix; that was a mistake. All new
 tags use `v`. Do not rename or delete the un-prefixed historical tags —
 they back published PyPI releases and GitHub Releases.
+
+Before cutting a release, promote the `[Unreleased]` section in
+`CHANGELOG.md` to the new version heading (see the Changelog section above).
 
 To cut a release (after confirming the version with the user):
 


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` covering all 24 releases from v0.1.0 (2026-02-11) through v0.12.0 (2026-05-05).
- Follows the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) convention: standard preamble, six change categories, ISO 8601 dates, reverse-chronological order, and an `[Unreleased]` staging section at the top.
- Curated rather than transcribed — CI tweaks, lockfile bumps, doc-site CSS, and internal refactors with no user-visible effect were dropped; related commits were merged into single entries.

## Notes for reviewers

- **Breaking changes are surfaced inline** with a `**Breaking:**` prefix in the relevant Changed/Removed entries (notably v0.6.0 strict-by-default and v0.10.0 `add(data=)` → `add(fields=)` and `[weather]` extra removal), per the spec's guidance on not adding a separate Breaking category.
- **Compare links handle the v-prefix split.** The `0.6.5` → `0.10.1` run was tagged without the `v` prefix (per `CLAUDE.md`, this was a known mistake). Compare URLs use the actual tag names so they resolve, while the changelog headings are kept clean as `[X.Y.Z]`.
- **v0.10.0 entries** infer that the `IDFDocument.add(data=)` → `add(fields=)` rename shipped in 0.10.0 based on the test commit referencing it. If the API rename actually shipped earlier, the entry should move.
- **0.6.5 coverage push** is summarized as a single Changed entry rather than dropped — it represents 16 PRs and a meaningful reduction in regression surface, even though no public API changed.
- The `[Unreleased]` section is intentionally empty (no commits between v0.12.0 and HEAD beyond this changelog itself).

## Test plan

- [ ] Spot-check a few compare links (e.g. `[0.6.5]`, `[0.10.2]`) to confirm GitHub resolves them given the mixed tag prefixes.
- [ ] Skim the v0.6.0 and v0.10.0 entries to confirm the breaking-change framing is accurate.
- [ ] Confirm the `[Unreleased]` section is the right shape for staging future entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)