### PR TITLE
fix(parsers): accept all EnergyPlus RDD/MDD formats (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- RDD/MDD parsers now match `Output:VariableDictionary, IDF` lines that include the `Zone Average` / `HVAC Sum` descriptor between `!-` and the units bracket. Previously `OutputVariableIndex.from_simulation()` silently returned zero variables on real EnergyPlus output. ([#154](https://github.com/idfkit/idfkit/issues/154))
+- MDD parser now recognizes `Output:Meter:Cumulative`, `Output:Meter:MeterFileOnly`, and `Output:Meter:Cumulative:MeterFileOnly` lines instead of silently skipping them. Cumulative variants are dropped from the result for now (a TODO tracks modeling all four variants on `OutputMeter`). ([#154](https://github.com/idfkit/idfkit/issues/154))
+
+### Added
+
+- RDD/MDD parsers now also accept the `Output:VariableDictionary, Regular` format (the EnergyPlus default). Both formats produce the same `OutputVariable` / `OutputMeter` set; for Regular lines, `key` is synthesized as `"*"` and `frequency` as `"hourly"` to match the IDF form. ([#154](https://github.com/idfkit/idfkit/issues/154))
+- `DictionaryParseWarning` is emitted when `parse_rdd` / `parse_mdd` produce zero entries from a non-empty file, surfacing format mismatches that would otherwise fail silently. ([#154](https://github.com/idfkit/idfkit/issues/154))
+
 ## [0.12.0] - 2026-05-05
 
 ### Added

--- a/src/idfkit/simulation/parsers/rdd.py
+++ b/src/idfkit/simulation/parsers/rdd.py
@@ -7,26 +7,80 @@ to discover available output variables and meters for a model.
 from __future__ import annotations
 
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
-# RDD line pattern:
-#   Output:Variable,*,Site Outdoor Air Drybulb Temperature,hourly; !- [C]
+# RDD line patterns. EnergyPlus emits one of two formats depending on the
+# `Output:VariableDictionary` key field:
+#
+#   IDF — `Output:VariableDictionary, IDF`. Each line is a ready-to-paste
+#   `Output:Variable` object, with the var type and report type collapsed
+#   into a "Zone Average" / "HVAC Sum" descriptor between `!-` and `[units]`.
+#   The descriptor is optional (older EP versions omit it):
+#
+#     Output:Variable,*,Site Outdoor Air Drybulb Temperature,hourly; !- Zone Average [C]
+#     Output:Variable,*,Zone Mean Air Temperature,hourly; !- [C]
+#
+#   Regular — `Output:VariableDictionary, Regular` (the EP default). Each
+#   line carries the var type and report type as separate fields, no key,
+#   no frequency:
+#
+#     Zone,Average,Site Outdoor Air Drybulb Temperature [C]
+#     HVAC,Sum,Zone Ideal Loads Supply Air Total Heating Energy [J]
+#
+# Both shapes must parse so callers don't have to know which format the
+# upstream model requested. For Regular lines we synthesize ``key="*"`` and
+# ``frequency="hourly"`` to match what EnergyPlus would have written in the
+# IDF form for the same variable.
 _RDD_RE = re.compile(
     r"^Output:Variable"
     r",\s*([^,]*)"  # key (e.g. "*")
     r",\s*([^,]*)"  # variable name
     r",\s*([^;]*)"  # frequency
-    r";\s*!-\s*\[([^\]]*)\]",  # units in comment
+    r";\s*!-[^\[]*\[([^\]]*)\]",  # optional descriptor + units in comment
+)
+_RDD_REGULAR_RE = re.compile(
+    r"^[A-Za-z]+"  # var type (Zone, HVAC) — discarded
+    r",\s*[A-Za-z]+"  # report type (Average, Sum) — discarded
+    r",\s*(.+?)\s*"  # variable name (non-greedy)
+    r"\[([^\]]*)\]\s*$",  # units in brackets at end
 )
 
-# MDD line pattern:
-#   Output:Meter,Electricity:Facility,hourly; !- [J]
+# MDD line patterns. EnergyPlus emits one of two formats:
+#
+#   IDF — up to four Output:Meter* variants, each with a frequency:
+#
+#     Output:Meter,Electricity:Facility,hourly; !- [J]
+#     Output:Meter:MeterFileOnly,Electricity:Facility,hourly; !- [J]
+#     Output:Meter:Cumulative,Electricity:Facility,hourly; !- [J]
+#     Output:Meter:Cumulative:MeterFileOnly,Electricity:Facility,hourly; !- [J]
+#
+#   Regular — single shape, no frequency, no cumulative variants:
+#
+#     Zone,Meter,Electricity:Facility [J]
+#
+# All shapes are recognized so they are not silently skipped. Cumulative IDF
+# variants are matched but dropped because OutputMeter has no notion of
+# cumulative-vs-running. For Regular lines we synthesize
+# ``frequency="hourly"`` to match what EnergyPlus would have written in the
+# IDF form.
+#
+# TODO: model the IDF four-variant landscape explicitly — likely as a
+# `cumulative: bool` and `meter_file_only: bool` pair on OutputMeter (or a
+# `kind` enum), with `add_all_to_model` choosing the right Output:Meter*
+# object type to inject.
 _MDD_RE = re.compile(
-    r"^Output:Meter"
+    r"^Output:Meter(:Cumulative)?(:MeterFileOnly)?"
     r",\s*([^,]*)"  # meter name
     r",\s*([^;]*)"  # frequency
-    r";\s*!-\s*\[([^\]]*)\]",  # units in comment
+    r";\s*!-[^\[]*\[([^\]]*)\]",  # optional descriptor + units in comment
+)
+_MDD_REGULAR_RE = re.compile(
+    r"^[A-Za-z]+"  # var type (typically "Zone") — discarded
+    r",\s*Meter"  # literal "Meter" column
+    r",\s*(.+?)\s*"  # meter name (may include colons and spaces)
+    r"\[([^\]]*)\]\s*$",  # units in brackets at end
 )
 
 
@@ -72,14 +126,51 @@ class OutputMeter:
     units: str
 
 
+class DictionaryParseWarning(UserWarning):
+    """Emitted when a non-empty ``.rdd`` / ``.mdd`` file parses to zero entries.
+
+    A non-empty dictionary file with zero parsed entries almost always means
+    EnergyPlus emitted a format the regex doesn't recognize, not that the
+    model genuinely exposes no variables / meters. The warning surfaces that
+    silent failure so callers don't get a confusingly empty
+    [OutputVariableIndex][idfkit.simulation.outputs.OutputVariableIndex].
+    """
+
+
+def _warn_if_silently_empty(text: str, parsed_count: int, kind: str) -> None:
+    """Warn when a non-empty dictionary file produced zero parsed entries."""
+    if parsed_count > 0:
+        return
+    if not any(line.strip() and not line.lstrip().startswith("!") for line in text.splitlines()):
+        return
+    warnings.warn(
+        f"Parsed 0 entries from a non-empty {kind} file. The file likely uses a format "
+        "this parser does not recognize; please report it at "
+        "https://github.com/idfkit/idfkit/issues with a sample line.",
+        DictionaryParseWarning,
+        stacklevel=3,
+    )
+
+
 def parse_rdd(text: str) -> tuple[OutputVariable, ...]:
     """Parse RDD content from a string.
+
+    Accepts both EnergyPlus output formats. ``Output:VariableDictionary, IDF``
+    lines preserve the original ``key`` and ``frequency``. ``Regular`` lines
+    don't carry that information, so ``key`` is synthesized as ``"*"`` and
+    ``frequency`` as ``"hourly"`` (the values EnergyPlus would have written
+    in the IDF form for the same variable).
 
     Args:
         text: Raw .rdd file contents.
 
     Returns:
         Tuple of parsed OutputVariable entries.
+
+    Warns:
+        DictionaryParseWarning: If *text* contains non-comment lines but
+            none of them parsed as either an IDF-form ``Output:Variable``
+            entry or a Regular-form variable row.
     """
     results: list[OutputVariable] = []
     for line in text.splitlines():
@@ -96,6 +187,18 @@ def parse_rdd(text: str) -> tuple[OutputVariable, ...]:
                     units=m.group(4).strip(),
                 )
             )
+            continue
+        m = _RDD_REGULAR_RE.match(line)
+        if m:
+            results.append(
+                OutputVariable(
+                    key="*",
+                    name=m.group(1).strip(),
+                    frequency="hourly",
+                    units=m.group(2).strip(),
+                )
+            )
+    _warn_if_silently_empty(text, len(results), ".rdd")
     return tuple(results)
 
 
@@ -115,26 +218,59 @@ def parse_rdd_file(path: str | Path) -> tuple[OutputVariable, ...]:
 def parse_mdd(text: str) -> tuple[OutputMeter, ...]:
     """Parse MDD content from a string.
 
+    Accepts both EnergyPlus output formats. In ``Output:VariableDictionary,
+    IDF`` mode all four meter variants (``Output:Meter``,
+    ``Output:Meter:MeterFileOnly``, ``Output:Meter:Cumulative``,
+    ``Output:Meter:Cumulative:MeterFileOnly``) are recognized; cumulative
+    entries are dropped since [OutputMeter][idfkit.simulation.parsers.rdd.OutputMeter]
+    does not yet distinguish cumulative from running, and ``MeterFileOnly``
+    variants collapse onto the same ``(name, frequency, units)`` as their
+    plain counterpart. ``Regular`` lines don't carry frequency, so it is
+    synthesized as ``"hourly"`` (Regular MDD does not list cumulative
+    variants).
+
     Args:
         text: Raw .mdd file contents.
 
     Returns:
-        Tuple of parsed OutputMeter entries.
+        Tuple of parsed OutputMeter entries (IDF cumulative variants dropped).
+
+    Warns:
+        DictionaryParseWarning: If *text* contains non-comment lines but
+            none of them parsed as either an IDF-form ``Output:Meter*``
+            entry or a Regular-form meter row.
     """
     results: list[OutputMeter] = []
+    matched = 0
     for line in text.splitlines():
         line = line.strip()
         if not line or line.startswith("!"):
             continue
         m = _MDD_RE.match(line)
         if m:
+            matched += 1
+            cumulative = m.group(1) is not None
+            if cumulative:
+                continue
+            results.append(
+                OutputMeter(
+                    name=m.group(3).strip(),
+                    frequency=m.group(4).strip(),
+                    units=m.group(5).strip(),
+                )
+            )
+            continue
+        m = _MDD_REGULAR_RE.match(line)
+        if m:
+            matched += 1
             results.append(
                 OutputMeter(
                     name=m.group(1).strip(),
-                    frequency=m.group(2).strip(),
-                    units=m.group(3).strip(),
+                    frequency="hourly",
+                    units=m.group(2).strip(),
                 )
             )
+    _warn_if_silently_empty(text, matched, ".mdd")
     return tuple(results)
 
 

--- a/tests/fixtures/simulation/sample.rdd
+++ b/tests/fixtures/simulation/sample.rdd
@@ -1,9 +1,9 @@
 ! Program Version,EnergyPlus, Version 24.1.0-69c052275a
 ! Output:Variable Objects (Alarm)
-Output:Variable,*,Site Outdoor Air Drybulb Temperature,hourly; !- [C]
-Output:Variable,*,Site Outdoor Air Wetbulb Temperature,hourly; !- [C]
-Output:Variable,*,Zone Mean Air Temperature,hourly; !- [C]
-Output:Variable,*,Zone Air System Sensible Heating Rate,hourly; !- [W]
-Output:Variable,*,Zone Air System Sensible Cooling Rate,hourly; !- [W]
-Output:Variable,*,Zone Ideal Loads Supply Air Total Heating Energy,hourly; !- [J]
-Output:Variable,*,Zone People Occupant Count,hourly; !- []
+Output:Variable,*,Site Outdoor Air Drybulb Temperature,hourly; !- Zone Average [C]
+Output:Variable,*,Site Outdoor Air Wetbulb Temperature,hourly; !- Zone Average [C]
+Output:Variable,*,Zone Mean Air Temperature,hourly; !- Zone Average [C]
+Output:Variable,*,Zone Air System Sensible Heating Rate,hourly; !- HVAC Average [W]
+Output:Variable,*,Zone Air System Sensible Cooling Rate,hourly; !- HVAC Average [W]
+Output:Variable,*,Zone Ideal Loads Supply Air Total Heating Energy,hourly; !- HVAC Sum [J]
+Output:Variable,*,Zone People Occupant Count,hourly; !- Zone Average []

--- a/tests/test_simulation_rdd_parser.py
+++ b/tests/test_simulation_rdd_parser.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from idfkit.simulation.parsers.rdd import (
+    DictionaryParseWarning,
     OutputMeter,
     OutputVariable,
     parse_mdd,
@@ -54,6 +55,61 @@ class TestParseRdd:
         assert variables[0].frequency == "timestep"
         assert variables[0].units == "kg/s"
 
+    def test_parse_rdd_idf_format_with_descriptor(self) -> None:
+        text = (
+            "Output:Variable,*,Site Outdoor Air Drybulb Temperature,hourly; !- Zone Average [C]\n"
+            "Output:Variable,*,Zone Air System Sensible Heating Rate,hourly; !- HVAC Sum [W]\n"
+        )
+        variables = parse_rdd(text)
+        assert len(variables) == 2
+        assert variables[0].name == "Site Outdoor Air Drybulb Temperature"
+        assert variables[0].units == "C"
+        assert variables[1].name == "Zone Air System Sensible Heating Rate"
+        assert variables[1].units == "W"
+
+    def test_parse_rdd_without_descriptor(self) -> None:
+        text = "Output:Variable,*,Test Variable,hourly; !- [C]\n"
+        variables = parse_rdd(text)
+        assert len(variables) == 1
+        assert variables[0].units == "C"
+
+    def test_parse_rdd_regular_format(self) -> None:
+        # `Output:VariableDictionary, Regular` writes lines without a key
+        # or frequency; both fields are synthesized to match the IDF form.
+        text = (
+            "Program Version,EnergyPlus, Version 24.1.0\n"
+            "Var Type (reported time step),Var Report Type,Variable Name [Units]\n"
+            "Zone,Average,Site Outdoor Air Drybulb Temperature [C]\n"
+            "HVAC,Sum,Zone Ideal Loads Supply Air Total Heating Energy [J]\n"
+            "Zone,Average,Site Outdoor Air Humidity Ratio [kgWater/kgDryAir]\n"
+        )
+        variables = parse_rdd(text)
+        assert len(variables) == 3
+        first = variables[0]
+        assert first.key == "*"
+        assert first.name == "Site Outdoor Air Drybulb Temperature"
+        assert first.frequency == "hourly"
+        assert first.units == "C"
+        assert variables[1].name == "Zone Ideal Loads Supply Air Total Heating Energy"
+        assert variables[1].units == "J"
+        # Slash-bearing units round-trip.
+        assert variables[2].units == "kgWater/kgDryAir"
+
+    def test_warns_when_silently_empty(self) -> None:
+        # Junk lines that match neither IDF nor Regular format.
+        text = "! header\nthis is not a dictionary line at all\n"
+        with pytest.warns(DictionaryParseWarning, match="Parsed 0 entries"):
+            variables = parse_rdd(text)
+        assert variables == ()
+
+    def test_no_warning_for_empty_input(self) -> None:
+        import warnings as _w
+
+        with _w.catch_warnings():
+            _w.simplefilter("error", DictionaryParseWarning)
+            assert parse_rdd("") == ()
+            assert parse_rdd("! only comments\n\n! more comments\n") == ()
+
     def test_skips_comments_and_blanks(self) -> None:
         text = "! This is a comment\n\n! Another comment\nOutput:Variable,*,Real Variable,hourly; !- [C]\n"
         variables = parse_rdd(text)
@@ -97,6 +153,52 @@ class TestParseMdd:
         assert meters[0].name == "CustomMeter:Zone1"
         assert meters[0].frequency == "timestep"
         assert meters[0].units == "W"
+
+    def test_parse_mdd_with_descriptor(self) -> None:
+        # `Output:VariableDictionary, IDF` may also place a descriptor between
+        # `!-` and `[` for meters in some EnergyPlus versions.
+        text = "Output:Meter,Electricity:Facility,hourly; !- HVAC Sum [J]\n"
+        meters = parse_mdd(text)
+        assert len(meters) == 1
+        assert meters[0].name == "Electricity:Facility"
+        assert meters[0].units == "J"
+
+    def test_parse_mdd_regular_format(self) -> None:
+        # `Output:VariableDictionary, Regular` MDD lines have no frequency;
+        # synthesized to "hourly" to match the IDF form.
+        text = (
+            "Program Version,EnergyPlus, Version 24.1.0\n"
+            "Var Type (reported time step),Var Report Type,Variable Name [Units]\n"
+            "Zone,Meter,Electricity:Facility [J]\n"
+            "Zone,Meter,InteriorLights:Electricity:Zone:BLOCK CORE STOREY 1 [J]\n"
+            "Zone,Meter,Carbon Equivalent:Facility [kg]\n"
+        )
+        meters = parse_mdd(text)
+        assert len(meters) == 3
+        assert meters[0].name == "Electricity:Facility"
+        assert meters[0].frequency == "hourly"
+        assert meters[0].units == "J"
+        # Meter names with colons and spaces.
+        assert meters[1].name == "InteriorLights:Electricity:Zone:BLOCK CORE STOREY 1"
+        assert meters[2].name == "Carbon Equivalent:Facility"
+        assert meters[2].units == "kg"
+
+    def test_drops_cumulative_variants(self) -> None:
+        # All four Output:Meter* variants are recognized; the two cumulative
+        # forms are dropped (no warning), the two non-cumulative forms are
+        # emitted as OutputMeter.
+        text = (
+            "Output:Meter,Electricity:Facility,hourly; !- [J]\n"
+            "Output:Meter:Cumulative,Electricity:Facility,hourly; !- [J]\n"
+            "Output:Meter:MeterFileOnly,InteriorLights:Electricity,hourly; !- [J]\n"
+            "Output:Meter:Cumulative:MeterFileOnly,InteriorLights:Electricity,hourly; !- [J]\n"
+        )
+        import warnings as _w
+
+        with _w.catch_warnings():
+            _w.simplefilter("error", DictionaryParseWarning)
+            meters = parse_mdd(text)
+        assert [m.name for m in meters] == ["Electricity:Facility", "InteriorLights:Electricity"]
 
     def test_skips_comments_and_blanks(self) -> None:
         text = "! comment line\n\nOutput:Meter,Electricity:Facility,hourly; !- [J]\n"


### PR DESCRIPTION
## Summary

- `OutputVariableIndex.from_simulation()` silently returned zero variables because the RDD regex didn't tolerate the `Zone Average` / `HVAC Sum` descriptor that EnergyPlus's `Output:VariableDictionary, IDF` form writes between `!-` and the units bracket.
- Cumulative and `MeterFileOnly` meter variants were unmatched by the MDD regex.
- The `Regular` format (EnergyPlus default) had no parser support at all — `prep_outputs` writes `Regular`, so the documented round-trip was broken end-to-end.

This change makes the parsers accept every format EnergyPlus emits, and adds a `DictionaryParseWarning` so future format drift can't silently empty the index.

## What changed

**`src/idfkit/simulation/parsers/rdd.py`**
- `_RDD_RE` now tolerates the optional descriptor between `!-` and `[units]`.
- New `_RDD_REGULAR_RE` parses `Zone,Average,Variable Name [Units]` rows; `key` is synthesized as `"*"` and `frequency` as `"hourly"` to match the IDF form.
- `_MDD_RE` recognizes all four meter variants: `Output:Meter`, `Output:Meter:MeterFileOnly`, `Output:Meter:Cumulative`, `Output:Meter:Cumulative:MeterFileOnly`. Cumulative entries are dropped pending an `OutputMeter` API change (TODO comment in source).
- New `_MDD_REGULAR_RE` parses `Zone,Meter,Meter:Name [Units]` rows.
- New `DictionaryParseWarning` fires when a non-empty `.rdd` / `.mdd` produces zero parsed entries.

**Verification**

Smoke-tested end-to-end against EnergyPlus 22.1 output from `1ZoneEvapCooler.idf` in both `Output:VariableDictionary` modes:

| Format | RDD | MDD |
|---|---|---|
| IDF | 417/417 | 43/43 |
| Regular | 417/417 | 43/43 |

Variable and meter name sets are identical across formats.

## Test plan

- [x] `make check` — pyright, ruff, deptry all pass
- [x] `make test` — 3162 passed, 1 skipped
- [x] New unit tests cover IDF-with-descriptor, IDF-without-descriptor, Regular RDD, Regular MDD, all four `Output:Meter*` IDF variants, the warning path, and the no-warning-on-empty-input path
- [x] Smoke-tested against real EnergyPlus 22.1 output in both formats

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)