### PR TITLE
fix(weather): sanitize DDY placeholder values before returning to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `WeatherDownloader.download()` now sanitizes extracted `.ddy` files by blanking out non-numeric placeholder tokens (`N`, `N/A`, ...) found in `SizingPeriod:DesignDay` numeric fields. Some upstream OneBuilding TMYx archives ship these placeholders when source data is unavailable, causing EnergyPlus to reject the file with a type-constraint fatal. Affected design day names are logged at WARNING. ([#156](https://github.com/idfkit/idfkit/issues/156))
-- EnergyPlus subprocesses (simulation, ExpandObjects, migration transition binaries) now have stdin explicitly redirected to `DEVNULL` instead of inheriting the parent's stdin. Prevents hangs on Windows when the parent process has a console attached. ([#158](https://github.com/idfkit/idfkit/pull/158))
-
 ### Added
 
-- `idfkit.weather.designday.sanitize_ddy_file()` exposes the DDY placeholder-stripping pass for callers that need to clean a DDY file outside the downloader flow. ([#156](https://github.com/idfkit/idfkit/issues/156))
+- `idfkit.weather.designday.sanitize_ddy_file()` for cleaning a DDY file outside the downloader flow. ([#156](https://github.com/idfkit/idfkit/issues/156))
+
+### Fixed
+
+- `WeatherDownloader.download()` now blanks out non-numeric placeholder tokens (`N`, `N/A`, ...) found in `SizingPeriod:DesignDay` numeric fields of extracted `.ddy` files. Some OneBuilding TMYx archives ship these placeholders when source data is unavailable, which previously caused EnergyPlus to reject the file with a type-constraint fatal. Affected design day names are logged at WARNING. ([#156](https://github.com/idfkit/idfkit/issues/156))
+- EnergyPlus subprocesses (simulation, ExpandObjects, migration transition binaries) now have stdin explicitly redirected to `DEVNULL` instead of inheriting the parent's stdin. Prevents hangs on Windows when the parent process has a console attached. ([#158](https://github.com/idfkit/idfkit/pull/158))
 
 ## [0.12.1] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `WeatherDownloader.download()` now blanks out non-numeric placeholder tokens (`N`, `N/A`, ...) found in `SizingPeriod:DesignDay` numeric fields of extracted `.ddy` files. Some OneBuilding TMYx archives ship these placeholders when source data is unavailable, which previously caused EnergyPlus to reject the file with a type-constraint fatal. Affected design day names are logged at WARNING. ([#156](https://github.com/idfkit/idfkit/issues/156))
+- `WeatherDownloader.download()` now blanks out the literal `N` placeholder token found in `SizingPeriod:DesignDay` numeric fields of extracted `.ddy` files. Some OneBuilding TMYx archives ship this placeholder when source data is unavailable, which previously caused EnergyPlus to reject the file with a type-constraint fatal. Affected design day names are logged at WARNING. ([#156](https://github.com/idfkit/idfkit/issues/156))
 - EnergyPlus subprocesses (simulation, ExpandObjects, migration transition binaries) now have stdin explicitly redirected to `DEVNULL` instead of inheriting the parent's stdin. Prevents hangs on Windows when the parent process has a console attached. ([#158](https://github.com/idfkit/idfkit/pull/158))
 
 ## [0.12.1] - 2026-05-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `WeatherDownloader.download()` now sanitizes extracted `.ddy` files by blanking out non-numeric placeholder tokens (`N`, `N/A`, ...) found in `SizingPeriod:DesignDay` numeric fields. Some upstream OneBuilding TMYx archives ship these placeholders when source data is unavailable, causing EnergyPlus to reject the file with a type-constraint fatal. Affected design day names are logged at WARNING. ([#156](https://github.com/idfkit/idfkit/issues/156))
+
+### Added
+
+- `idfkit.weather.designday.sanitize_ddy_file()` exposes the DDY placeholder-stripping pass for callers that need to clean a DDY file outside the downloader flow. ([#156](https://github.com/idfkit/idfkit/issues/156))
+
 ## [0.12.1] - 2026-05-06
 
 ### Fixed

--- a/src/idfkit/weather/designday.py
+++ b/src/idfkit/weather/designday.py
@@ -23,10 +23,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Tokens that some upstream DDY providers use as placeholders in numeric fields
-# when source data is unavailable (e.g. OneBuilding's "MWB=NC" / "WS=N/A"
-# header notes). EnergyPlus rejects these as type-constraint violations.
-_DDY_PLACEHOLDER_TOKENS: frozenset[str] = frozenset({"N", "N/A", "NA", "NC", "N.C."})
+# OneBuilding TMYx DDY files use a literal ``N`` in numeric fields of
+# ``SizingPeriod:DesignDay`` when source data is unavailable (header comments
+# call these out as ``MWB=NC`` / ``WS=N/A``). EnergyPlus rejects the file
+# with a type-constraint fatal. This is a defensive, narrow workaround to
+# unblock users while the upstream data is corrected.
+_DDY_PLACEHOLDER_TOKENS: frozenset[str] = frozenset({"N"})
 
 # Matches a single field value within a SizingPeriod:DesignDay block: the
 # value is the run of non-whitespace, non-delimiter characters following an

--- a/src/idfkit/weather/designday.py
+++ b/src/idfkit/weather/designday.py
@@ -7,6 +7,7 @@ ASHRAE design-condition categories.
 
 from __future__ import annotations
 
+import logging
 import re
 from enum import Enum
 from pathlib import Path
@@ -19,6 +20,100 @@ if TYPE_CHECKING:
     from ..document import IDFDocument
     from ..objects import IDFObject
     from .station import WeatherStation
+
+logger = logging.getLogger(__name__)
+
+# Tokens that some upstream DDY providers use as placeholders in numeric fields
+# when source data is unavailable (e.g. OneBuilding's "MWB=NC" / "WS=N/A"
+# header notes). EnergyPlus rejects these as type-constraint violations.
+_DDY_PLACEHOLDER_TOKENS: frozenset[str] = frozenset({"N", "N/A", "NA", "NC", "N.C.", "-"})
+
+# Matches a single field value within a SizingPeriod:DesignDay block: the
+# value is the run of non-whitespace, non-delimiter characters following an
+# optional leading whitespace, terminated by ``,`` ``;`` or ``!`` (comment).
+_SIZING_DESIGN_DAY_BLOCK = re.compile(
+    r"SizingPeriod:DesignDay\s*,.*?;",
+    re.IGNORECASE | re.DOTALL,
+)
+_FIELD_VALUE = re.compile(r"(?P<lead>[,\n]\s*)(?P<value>[^,;!\s]+)(?P<trail>\s*(?=[,;!]))")
+
+
+def _sanitize_ddy_text(text: str) -> tuple[str, list[str]]:
+    """Blank out placeholder field values in ``SizingPeriod:DesignDay`` objects.
+
+    Some upstream DDY archives use literal tokens such as ``N`` / ``N/A`` in
+    numeric fields where source data is unavailable. EnergyPlus rejects these
+    as type-constraint violations. For each affected field we replace the
+    placeholder with an empty value (which EnergyPlus treats as defaulted),
+    preserving the surrounding design day object so the annual sizing data
+    remains usable.
+
+    Returns:
+        A ``(new_text, patched_names)`` tuple. ``patched_names`` lists the
+        ``SizingPeriod:DesignDay`` object names that had at least one field
+        blanked.
+    """
+    patched: list[str] = []
+
+    def _patch_block(match: re.Match[str]) -> str:
+        block = match.group(0)
+        # Extract the Name (first field after the type keyword) for logging.
+        no_comments = re.sub(r"!.*", "", block)
+        _, _, body = no_comments.partition(",")
+        body = body.rstrip().rstrip(";")
+        first_field = body.split(",", 1)[0].strip() if body else ""
+        name = first_field or "<unnamed>"
+
+        block_changed = False
+
+        def _patch_field(field_match: re.Match[str]) -> str:
+            nonlocal block_changed
+            value = field_match.group("value")
+            if value.upper() in _DDY_PLACEHOLDER_TOKENS:
+                block_changed = True
+                return field_match.group("lead") + field_match.group("trail")
+            return field_match.group(0)
+
+        new_block = _FIELD_VALUE.sub(_patch_field, block)
+        if block_changed:
+            patched.append(name)
+        return new_block
+
+    new_text = _SIZING_DESIGN_DAY_BLOCK.sub(_patch_block, text)
+    return new_text, patched
+
+
+def sanitize_ddy_file(ddy_path: Path | str) -> list[str]:
+    """Blank placeholder values in ``SizingPeriod:DesignDay`` fields of a DDY file.
+
+    Some upstream DDY archives (notably OneBuilding TMYx files) contain a
+    literal ``N`` token in numeric fields of ``SizingPeriod:DesignDay`` when
+    the underlying source data is unavailable. EnergyPlus rejects such files
+    with a fatal type-constraint error. This helper rewrites the file in
+    place, replacing each placeholder with an empty field (which EnergyPlus
+    treats as defaulted) so the surrounding design day object remains usable.
+
+    Args:
+        ddy_path: Path to a ``.ddy`` file.
+
+    Returns:
+        List of design day names that had at least one field blanked. Empty
+        if the file was already clean.
+    """
+    path = Path(ddy_path)
+    # Use binary I/O so original line endings (CRLF on OneBuilding archives,
+    # LF elsewhere) are preserved verbatim across the round-trip.
+    text = path.read_bytes().decode("utf-8", errors="replace")
+    new_text, patched = _sanitize_ddy_text(text)
+    if patched:
+        path.write_bytes(new_text.encode("utf-8"))
+        logger.warning(
+            "Sanitized %s: blanked non-numeric placeholder values in %d SizingPeriod:DesignDay object(s): %s",
+            path.name,
+            len(patched),
+            ", ".join(patched),
+        )
+    return patched
 
 
 class DesignDayType(Enum):

--- a/src/idfkit/weather/download.py
+++ b/src/idfkit/weather/download.py
@@ -109,6 +109,14 @@ class WeatherDownloader:
             If ``None`` (default), cached files never expire.
 
     Note:
+        Extracted ``.ddy`` files are rewritten in place to drop
+        ``SizingPeriod:DesignDay`` objects whose numeric fields contain
+        non-numeric placeholder tokens (e.g. ``N``, ``N/A``). These appear
+        in some upstream archives when source data is unavailable and
+        would otherwise cause EnergyPlus to fail with a type-constraint
+        error.
+
+    Note:
         The cache has no size limit. For CI/CD environments with limited disk
         space, consider using [clear_cache][idfkit.weather.download.WeatherDownloader.clear_cache] periodically or setting
         a ``max_age`` to force re-downloads of stale files.
@@ -200,6 +208,11 @@ class WeatherDownloader:
         epw_path = self._find_file(station_dir, ".epw")
         ddy_path = self._find_file(station_dir, ".ddy")
         stat_path = self._find_file(station_dir, ".stat")
+
+        if ddy_path is not None:
+            from .designday import sanitize_ddy_file
+
+            sanitize_ddy_file(ddy_path)
 
         if only_set is not None:
             return PartialWeatherFiles(

--- a/tests/test_weather_designday.py
+++ b/tests/test_weather_designday.py
@@ -589,11 +589,18 @@ class TestSanitizeDdyFile:
         assert patched == []
         assert ddy.read_text() == original
 
-    def test_recognises_n_slash_a(self, tmp_path: Path) -> None:
-        ddy = tmp_path / "broken.ddy"
-        ddy.write_text(self._BAD_DD.replace("          N,", "        N/A,"))
+    def test_leaves_other_non_numeric_tokens_alone(self, tmp_path: Path) -> None:
+        """Only the literal ``N`` is sanitized; other oddities pass through.
+
+        OneBuilding only ships ``N`` as the placeholder; the upstream issue
+        has been reported separately. Keep the workaround narrow so we do
+        not silently rewrite values we did not intend to.
+        """
+        ddy = tmp_path / "weird.ddy"
+        block_with_na = self._BAD_DD.replace("          N,", "        N/A,")
+        ddy.write_text(block_with_na)
 
         patched = sanitize_ddy_file(ddy)
 
-        assert patched == ["Boston January .4% Condns DB=>MCWB"]
-        assert "N/A" not in ddy.read_text()
+        assert patched == []
+        assert "N/A" in ddy.read_text()

--- a/tests/test_weather_designday.py
+++ b/tests/test_weather_designday.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ from idfkit.weather.designday import (
     DesignDayType,
     _classify_design_day,  # pyright: ignore[reportPrivateUsage]
     apply_ashrae_sizing,
+    sanitize_ddy_file,
 )
 from idfkit.weather.station import WeatherStation
 
@@ -521,3 +523,77 @@ class TestApplyAshraeSizing:
             pytest.raises(NoDesignDaysError),
         ):
             apply_ashrae_sizing(model, station)
+
+
+class TestSanitizeDdyFile:
+    """Tests for sanitize_ddy_file (issue #156)."""
+
+    _GOOD_DD = (
+        "SizingPeriod:DesignDay,\n"
+        "    Boston Ann Htg 99.6% Condns DB,  !- Name\n"
+        "    1,                          !- Month\n"
+        "    21,                         !- Day of Month\n"
+        "    WinterDesignDay,            !- Day Type\n"
+        "    -14.7,                      !- Maximum Dry-Bulb Temperature {C}\n"
+        "    0.0,                        !- Daily Dry-Bulb Temperature Range\n"
+        "    DefaultMultipliers,         !- Range Modifier Type\n"
+        "    ,                           !- Range Modifier Day Schedule Name\n"
+        "    Wetbulb,                    !- Humidity Condition Type\n"
+        "    -14.7,                      !- Wetbulb at Maximum Dry-Bulb {C}\n"
+        "    101325.,                    !- Barometric Pressure {Pa}\n"
+        "    4.9,                        !- Wind Speed {m/s}\n"
+        "    270;                        !- Wind Direction {deg}\n"
+    )
+
+    _BAD_DD = (
+        "SizingPeriod:DesignDay,\n"
+        "    Boston January .4% Condns DB=>MCWB,  !- Name\n"
+        "    1,                          !- Month\n"
+        "    21,                         !- Day of Month\n"
+        "    SummerDesignDay,            !- Day Type\n"
+        "    12.3,                       !- Maximum Dry-Bulb Temperature {C}\n"
+        "    0.0,                        !- Daily Dry-Bulb Temperature Range\n"
+        "    DefaultMultipliers,         !- Range Modifier Type\n"
+        "    ,                           !- Range Modifier Day Schedule Name\n"
+        "    Wetbulb,                    !- Humidity Condition Type\n"
+        "          N,                    !- Wetbulb at Maximum Dry-Bulb {C}\n"
+        "    101325.,                    !- Barometric Pressure {Pa}\n"
+        "          N,                    !- Wind Speed {m/s}\n"
+        "    270;                        !- Wind Direction {deg}\n"
+    )
+
+    def test_blanks_placeholders_keeping_block(self, tmp_path: Path) -> None:
+        ddy = tmp_path / "broken.ddy"
+        ddy.write_text(self._GOOD_DD + "\n" + self._BAD_DD)
+
+        patched = sanitize_ddy_file(ddy)
+
+        assert patched == ["Boston January .4% Condns DB=>MCWB"]
+        new_text = ddy.read_text()
+        # Both design days are still present.
+        assert "Boston Ann Htg 99.6%" in new_text
+        assert "Boston January .4% Condns DB=>MCWB" in new_text
+        # The literal ``N`` field values are gone.
+        assert re.search(r"^\s*N\s*,", new_text, re.MULTILINE) is None
+        # Other fields are untouched.
+        assert "101325." in new_text
+        assert "12.3" in new_text
+
+    def test_clean_file_is_untouched(self, tmp_path: Path) -> None:
+        ddy = tmp_path / "clean.ddy"
+        original = self._GOOD_DD
+        ddy.write_text(original)
+
+        patched = sanitize_ddy_file(ddy)
+
+        assert patched == []
+        assert ddy.read_text() == original
+
+    def test_recognises_n_slash_a(self, tmp_path: Path) -> None:
+        ddy = tmp_path / "broken.ddy"
+        ddy.write_text(self._BAD_DD.replace("          N,", "        N/A,"))
+
+        patched = sanitize_ddy_file(ddy)
+
+        assert patched == ["Boston January .4% Condns DB=>MCWB"]
+        assert "N/A" not in ddy.read_text()


### PR DESCRIPTION
## Summary

- `WeatherDownloader.download()` now rewrites extracted `.ddy` files in place to blank out the literal `N` placeholder token that some upstream archives use in `SizingPeriod:DesignDay` numeric fields when source data is unavailable. EnergyPlus treats blanks as defaulted, so the surrounding design day object stays usable — only the bad field values are removed.
- New public helper `idfkit.weather.designday.sanitize_ddy_file()` exposes the same pass for callers that get a DDY through another route.
- Affected design day names are logged at WARNING. Line endings (CRLF on OneBuilding archives) are preserved via binary I/O.

## Why

Some OneBuilding TMYx DDY archives (e.g. `USA_MA_Boston.994971_TMYx.2004-2018.ddy`) contain a literal `N` in numeric fields where the source data was unavailable. Handing such a file to EnergyPlus produces a fatal type-constraint error on `SizingPeriod:DesignDay` — see [#156](https://github.com/idfkit/idfkit/issues/156).

This is a defensive, narrow workaround to unblock users while OneBuilding corrects the data at the source (they have already been notified). Only the literal `N` token is matched — other oddities (`N/A`, `NA`, …) are left alone so we don't silently rewrite values we didn't intend to.

Verified end-to-end on the Boston archive from the issue: the diff against the original file is exactly two lines (the `N` Wetbulb and Wind Speed values blanked); every other byte (including CRLF endings) is preserved.

Closes [#156](https://github.com/idfkit/idfkit/issues/156).

## Test plan

- [x] New unit tests in `TestSanitizeDdyFile` cover placeholder blanking, the no-op case on clean files, and confirm that non-`N` oddities like `N/A` pass through untouched.
- [x] `uv run pytest tests/test_weather_designday.py tests/test_weather_download.py` — 83 passed.
- [x] Manual verification on the real OneBuilding Boston DDY: minimal 2-line diff, file remains valid IDF syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)