### PR TITLE
Close subprocess stdin for EnergyPlus tools

### DIFF
--- a/src/idfkit/migration/async_subprocess_backend.py
+++ b/src/idfkit/migration/async_subprocess_backend.py
@@ -57,6 +57,7 @@ class AsyncSubprocessMigrator:
             proc = await asyncio.create_subprocess_exec(
                 str(binary),
                 str(input_idf),
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(work_dir),

--- a/src/idfkit/migration/subprocess_backend.py
+++ b/src/idfkit/migration/subprocess_backend.py
@@ -63,6 +63,7 @@ class SubprocessMigrator:
         try:
             proc = subprocess.run(  # noqa: S603
                 [str(binary), str(input_idf)],
+                stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
                 timeout=self.step_timeout,

--- a/src/idfkit/simulation/async_runner.py
+++ b/src/idfkit/simulation/async_runner.py
@@ -294,6 +294,7 @@ async def _run_simple(
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(run_dir),
@@ -376,6 +377,7 @@ async def _start_process(
     try:
         return await asyncio.create_subprocess_exec(
             *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(run_dir),

--- a/src/idfkit/simulation/expand.py
+++ b/src/idfkit/simulation/expand.py
@@ -180,6 +180,7 @@ def _run_subprocess(
     try:
         return subprocess.run(  # noqa: S603
             [str(exe)],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/src/idfkit/simulation/runner.py
+++ b/src/idfkit/simulation/runner.py
@@ -271,6 +271,7 @@ def _run_simple(
     try:
         proc = subprocess.run(  # noqa: S603
             cmd,
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -305,6 +306,7 @@ def _run_with_progress(
     try:
         proc = subprocess.Popen(  # noqa: S603
             cmd,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,


### PR DESCRIPTION
## Summary

Close stdin for EnergyPlus-related subprocess launches by passing `stdin=DEVNULL` in the sync and async simulation runners, preprocessors, and migration subprocess backends.

## Root Cause

On Windows, when idfkit is used through a stdio MCP server, EnergyPlus can inherit the MCP server's stdin pipe. A full EnergyPlus run then hangs before producing the normal output files. The same EnergyPlus command completes when its child stdin is detached.

## Impact

This prevents `run_simulation` from hanging on Windows stdio clients while preserving stdout/stderr capture and existing timeout behavior. The same stdin isolation is applied to ExpandObjects, Slab/Basement, and IDF transition subprocesses because they are launched from the same kind of host process.

## Validation

- Reproduced the stdio MCP hang on Windows with `idfkit-mcp` and EnergyPlus 23.1: the call timed out after 180s and only `model.idf`, the EPW, and an empty `eplus.err` were present.
- Confirmed the same full EnergyPlus subprocess completes when launched with `stdin=DEVNULL`.
- Re-ran the stdio MCP repro with patched `idfkit` on `PYTHONPATH`: `run_simulation` completed successfully in ~1.7s.
- Ran `uv run pytest tests/test_simulation_async.py tests/test_simulation_runner.py -q`: `75 passed`.

Note: broader Windows test runs expose unrelated fixture assumptions around extensionless fake executables for ExpandObjects/migration tests; the focused simulation runner tests pass.