### PR TITLE
Add EnergyPlus discovery for Claude Code web environment

### DIFF
--- a/docs/agent-references/simulation-execution.md
+++ b/docs/agent-references/simulation-execution.md
@@ -46,7 +46,7 @@
 --8<-- "docs/snippets/agent_references/simulation-execution.py:discover"
 ```
 
-Discovery checks `$ENERGYPLUS_DIR`, `$PATH`, and standard install locations (`/usr/local/EnergyPlus-*`, `/Applications/EnergyPlus-*`, `C:\EnergyPlusV*`). Pass the result to `simulate(..., energyplus=config)` to skip rediscovery on every call.
+Discovery checks `$ENERGYPLUS_DIR`, `$PATH`, and standard install locations (`/usr/local/EnergyPlus-*`, `/Applications/EnergyPlus-*`, `C:\EnergyPlusV*`, plus `/opt/eplus` for Claude Code web sessions). Pass the result to `simulate(..., energyplus=config)` to skip rediscovery on every call.
 
 If EnergyPlus is missing, `EnergyPlusNotFoundError` is raised.
 

--- a/src/idfkit/.agents/skills/developing-with-idfkit/references/simulation-execution.md
+++ b/src/idfkit/.agents/skills/developing-with-idfkit/references/simulation-execution.md
@@ -66,7 +66,7 @@ config = find_energyplus(version=(24, 1, 0))
 print(config.executable, config.version)
 ```
 
-Discovery checks `$ENERGYPLUS_DIR`, `$PATH`, and standard install locations (`/usr/local/EnergyPlus-*`, `/Applications/EnergyPlus-*`, `C:\EnergyPlusV*`). Pass the result to `simulate(..., energyplus=config)` to skip rediscovery on every call.
+Discovery checks `$ENERGYPLUS_DIR`, `$PATH`, and standard install locations (`/usr/local/EnergyPlus-*`, `/Applications/EnergyPlus-*`, `C:\EnergyPlusV*`, plus `/opt/eplus` for Claude Code web sessions). Pass the result to `simulate(..., energyplus=config)` to skip rediscovery on every call.
 
 If EnergyPlus is missing, `EnergyPlusNotFoundError` is raised.
 

--- a/src/idfkit/simulation/config.py
+++ b/src/idfkit/simulation/config.py
@@ -253,6 +253,9 @@ def _discovery_candidates() -> list[Path]:
     if which_result:
         candidates.append(Path(which_result).resolve())
 
+    # Claude Code on the web installs EnergyPlus at this standard location
+    candidates.append(Path("/opt/eplus"))
+
     candidates.extend(_glob_sorted(_platform_search_dirs()))
     return candidates
 


### PR DESCRIPTION
## Summary

Add support for discovering EnergyPlus installations in the Claude Code web environment, which installs EnergyPlus at the standard location `/opt/eplus`.

## Changes

- Added `/opt/eplus` to the EnergyPlus discovery candidates list in `_discovery_candidates()` 
- This path is checked after the `which` command but before platform-specific search directories
- Enables seamless EnergyPlus simulation execution when running idfkit in Claude Code on the web

## Implementation Details

The discovery mechanism now includes the standard Claude Code web installation path as an explicit candidate, ensuring that users working in that environment can run simulations without manual configuration.

https://claude.ai/code/session_01LfYcX6kkgT84bquA5c5LtY