### PR TITLE
fix(simulation): release SQLite handle so run dirs can be deleted on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `SimulationResult` is now a context manager and exposes `SimulationResult.close()`. Closing releases the SQLite connection opened lazily by `result.sql` (and deletes the temporary copy made for remote file system backends). ([#164](https://github.com/idfkit/idfkit/pull/164))
+
+### Fixed
+
+- Reading `result.sql` left a SQLite connection open for the lifetime of the `SimulationResult`, which on Windows kept an OS-level lock on `eplus.sql` and made deleting the run directory fail with `PermissionError [WinError 32]` (e.g. when the run directory lived inside a `tempfile.TemporaryDirectory`). The connection now releases its handle when the result is closed — use `with simulate(...) as result:` or call `result.close()` before removing the run directory. As a safety net, `SQLResult` also closes its connection on garbage collection. ([#164](https://github.com/idfkit/idfkit/pull/164))
+
 ## [0.13.0] - 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `SimulationResult` is now a context manager and exposes `SimulationResult.close()`. Closing releases the SQLite connection opened lazily by `result.sql` (and deletes the temporary copy made for remote file system backends). ([#164](https://github.com/idfkit/idfkit/pull/164))
+- `SimulationResult` is now a context manager and exposes `SimulationResult.close()`. Closing releases the SQLite connection opened lazily by `result.sql` (and deletes the temporary copy made for remote file system backends). ([#170](https://github.com/idfkit/idfkit/pull/170))
 
 ### Fixed
 
-- Reading `result.sql` left a SQLite connection open for the lifetime of the `SimulationResult`, which on Windows kept an OS-level lock on `eplus.sql` and made deleting the run directory fail with `PermissionError [WinError 32]` (e.g. when the run directory lived inside a `tempfile.TemporaryDirectory`). The connection now releases its handle when the result is closed — use `with simulate(...) as result:` or call `result.close()` before removing the run directory. As a safety net, `SQLResult` also closes its connection on garbage collection. ([#164](https://github.com/idfkit/idfkit/pull/164))
+- Reading `result.sql` left a SQLite connection open for the lifetime of the `SimulationResult`, which on Windows kept an OS-level lock on `eplus.sql` and made deleting the run directory fail with `PermissionError [WinError 32]` (e.g. when the run directory lived inside a `tempfile.TemporaryDirectory`). The connection now releases its handle when the result is closed — use `with simulate(...) as result:` or call `result.close()` before removing the run directory. As a safety net, `SQLResult` also closes its connection on garbage collection. ([#170](https://github.com/idfkit/idfkit/pull/170))
 
 ## [0.13.0] - 2026-05-26
 

--- a/docs/agent-references/result-parsing.md
+++ b/docs/agent-references/result-parsing.md
@@ -122,6 +122,18 @@ If you've simulated outside Python (or cached the outputs), rebuild a `Simulatio
 --8<-- "docs/snippets/agent_references/result-parsing.py:from-directory"
 ```
 
+## Releasing file handles (`close` / context manager)
+
+`result.sql` opens a SQLite connection on first access and caches it. That connection holds an OS-level lock on `eplus.sql`. On **Windows**, the lock blocks deleting the run directory — `shutil.rmtree` / `TemporaryDirectory` cleanup fails with `PermissionError [WinError 32]: the process cannot access the file because it is being used by another process`. POSIX doesn't lock on open, so this only bites Windows users.
+
+Close the result — or use it as a context manager — before the run directory is removed:
+
+```python
+--8<-- "docs/snippets/agent_references/result-parsing.py:closing"
+```
+
+`close()` is idempotent and resets the cached connection, so touching `result.sql` afterwards transparently reopens it. The other accessors (`errors`, `csv`, `eso`, `html`, `variables`) read their files eagerly and hold no handles, so they need no cleanup.
+
 ## Plotting helpers
 
 ```python

--- a/docs/snippets/agent_references/result-parsing.py
+++ b/docs/snippets/agent_references/result-parsing.py
@@ -175,6 +175,27 @@ result = SimulationResult.from_directory("/path/to/run", output_prefix="eplus")
 # --8<-- [end:from-directory]
 
 
+# --8<-- [start:closing]
+import tempfile
+from pathlib import Path
+
+# result.sql opens a SQLite connection that holds an OS lock on eplus.sql.
+# On Windows that lock blocks deletion of the run directory. Close the result
+# (or use it as a context manager) before the directory is removed. The result
+# context exits first — closing the connection — then TemporaryDirectory cleans
+# up, so rmtree succeeds.
+with tempfile.TemporaryDirectory() as tmp, simulate(doc, "weather.epw", output_dir=Path(tmp) / "run") as result:
+    temps = result.sql.get_timeseries("Zone Mean Air Temperature", "Office")
+
+# Equivalent without a context manager:
+result = simulate(doc, "weather.epw")
+try:
+    temps = result.sql.get_timeseries("Zone Mean Air Temperature", "Office")
+finally:
+    result.close()  # idempotent; reopens lazily if you touch result.sql again
+# --8<-- [end:closing]
+
+
 # --8<-- [start:plotting]
 from idfkit.simulation.plotting import (
     plot_temperature_profile,

--- a/src/idfkit/.agents/skills/developing-with-idfkit/references/result-parsing.md
+++ b/src/idfkit/.agents/skills/developing-with-idfkit/references/result-parsing.md
@@ -231,6 +231,34 @@ from idfkit.simulation import SimulationResult
 result = SimulationResult.from_directory("/path/to/run", output_prefix="eplus")
 ```
 
+## Releasing file handles (`close` / context manager)
+
+`result.sql` opens a SQLite connection on first access and caches it. That connection holds an OS-level lock on `eplus.sql`. On **Windows**, the lock blocks deleting the run directory — `shutil.rmtree` / `TemporaryDirectory` cleanup fails with `PermissionError [WinError 32]: the process cannot access the file because it is being used by another process`. POSIX doesn't lock on open, so this only bites Windows users.
+
+Close the result — or use it as a context manager — before the run directory is removed:
+
+```python
+import tempfile
+from pathlib import Path
+
+# result.sql opens a SQLite connection that holds an OS lock on eplus.sql.
+# On Windows that lock blocks deletion of the run directory. Close the result
+# (or use it as a context manager) before the directory is removed. The result
+# context exits first — closing the connection — then TemporaryDirectory cleans
+# up, so rmtree succeeds.
+with tempfile.TemporaryDirectory() as tmp, simulate(doc, "weather.epw", output_dir=Path(tmp) / "run") as result:
+    temps = result.sql.get_timeseries("Zone Mean Air Temperature", "Office")
+
+# Equivalent without a context manager:
+result = simulate(doc, "weather.epw")
+try:
+    temps = result.sql.get_timeseries("Zone Mean Air Temperature", "Office")
+finally:
+    result.close()  # idempotent; reopens lazily if you touch result.sql again
+```
+
+`close()` is idempotent and resets the cached connection, so touching `result.sql` afterwards transparently reopens it. The other accessors (`errors`, `csv`, `eso`, `html`, `variables`) read their files eagerly and hold no handles, so they need no cleanup.
+
 ## Plotting helpers
 
 ```python

--- a/src/idfkit/simulation/parsers/sql.py
+++ b/src/idfkit/simulation/parsers/sql.py
@@ -7,6 +7,7 @@ metadata from the ``eplusout.sql`` database produced by EnergyPlus when
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
@@ -183,24 +184,50 @@ class SQLResult:
         ```
     """
 
-    def __init__(self, db_path: str | Path) -> None:
+    def __init__(self, db_path: str | Path, *, _owns_file: bool = False) -> None:
         """Open the SQLite database in read-only mode.
 
         Args:
             db_path: Path to the EnergyPlus ``.sql`` output file.
+            _owns_file: Internal flag. When ``True``, [close][idfkit.simulation.parsers.sql.SQLResult.close]
+                also unlinks ``db_path`` — used when the file is a temporary
+                copy made for a remote file system backend.
         """
         self._db_path = Path(db_path)
+        self._owns_file = _owns_file
+        self._closed = False
         self._conn = sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True)
 
     def close(self) -> None:
-        """Close the database connection."""
+        """Close the database connection.
+
+        Releases the underlying OS file handle. This matters on Windows,
+        where an open SQLite connection holds a lock that prevents the
+        ``.sql`` file (and any directory containing it) from being deleted.
+        Safe to call more than once.
+        """
+        if self._closed:
+            return
+        self._closed = True
         self._conn.close()
+        if self._owns_file:
+            with contextlib.suppress(OSError):
+                self._db_path.unlink()
 
     def __enter__(self) -> SQLResult:
         return self
 
     def __exit__(self, *exc: object) -> None:
         self.close()
+
+    def __del__(self) -> None:
+        # Safety net: release the file handle if the caller never closed the
+        # connection. Guarded because __init__ may have failed before _conn
+        # was assigned. Errors during interpreter shutdown are ignored.
+        if getattr(self, "_closed", True):
+            return
+        with contextlib.suppress(Exception):
+            self.close()
 
     def get_timeseries(
         self,

--- a/src/idfkit/simulation/result.py
+++ b/src/idfkit/simulation/result.py
@@ -70,6 +70,31 @@ class SimulationResult:
             msg = "fs and async_fs are mutually exclusive — provide one or neither"
             raise ValueError(msg)
 
+    def close(self) -> None:
+        """Release any open file handles held by cached parsers.
+
+        Closes the SQLite connection opened lazily by [sql][idfkit.simulation.result.SimulationResult.sql] /
+        [async_sql][idfkit.simulation.result.SimulationResult.async_sql] (and removes the temporary copy made
+        for remote file systems). The other parsers read their files eagerly
+        and hold no handles, so this is currently a no-op for them.
+
+        Call this — or use the result as a context manager — before deleting
+        the run directory. On Windows an open SQLite connection locks
+        ``eplus.sql`` and blocks ``shutil.rmtree`` / ``TemporaryDirectory``
+        cleanup with ``PermissionError [WinError 32]``. Safe to call more
+        than once; the cached connection is reopened on next access if needed.
+        """
+        cached = object.__getattribute__(self, "_cached_sql")
+        if cached is not _UNSET and cached is not None:
+            cached.close()
+        object.__setattr__(self, "_cached_sql", _UNSET)
+
+    def __enter__(self) -> SimulationResult:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
     @property
     def errors(self) -> ErrorReport:
         """Parsed error report from the .err file (lazily cached).
@@ -113,7 +138,7 @@ class SimulationResult:
             data = self.fs.read_bytes(str(path))
             with tempfile.NamedTemporaryFile(suffix=".sql", delete=False) as tmp_file:
                 tmp_file.write(data)
-            result: SQLResult = _SQLResult(Path(tmp_file.name))
+            result: SQLResult = _SQLResult(Path(tmp_file.name), _owns_file=True)
         else:
             result = _SQLResult(path)
         object.__setattr__(self, "_cached_sql", result)
@@ -395,12 +420,12 @@ class SimulationResult:
             data = await self.async_fs.read_bytes(str(path))
             with tempfile.NamedTemporaryFile(suffix=".sql", delete=False) as tmp_file:
                 tmp_file.write(data)
-            result: SQLResult = _SQLResult(Path(tmp_file.name))
+            result: SQLResult = _SQLResult(Path(tmp_file.name), _owns_file=True)
         elif self.fs is not None:
             data = self.fs.read_bytes(str(path))
             with tempfile.NamedTemporaryFile(suffix=".sql", delete=False) as tmp_file:
                 tmp_file.write(data)
-            result = _SQLResult(Path(tmp_file.name))
+            result = _SQLResult(Path(tmp_file.name), _owns_file=True)
         else:
             result = _SQLResult(path)
         object.__setattr__(self, "_cached_sql", result)

--- a/tests/test_simulation_result.py
+++ b/tests/test_simulation_result.py
@@ -130,6 +130,63 @@ class TestSqlProperty:
         assert ts.values[0] == -5.0
 
 
+class TestClose:
+    """Tests for SimulationResult.close() / context manager releasing handles."""
+
+    def test_close_releases_sql_connection_and_allows_rmtree(self, result_dir: Path) -> None:
+        # Reproduces the Windows WinError 32 scenario: an open SQLite
+        # connection must not keep the run directory locked after close().
+        result = SimulationResult(
+            run_dir=result_dir, success=True, exit_code=0, stdout="", stderr="", runtime_seconds=0.0
+        )
+        sql = result.sql
+        assert sql is not None
+        _ = sql.get_timeseries("Site Outdoor Air Drybulb Temperature")  # force a real read
+
+        result.close()
+
+        # Connection is closed; querying it now raises.
+        with pytest.raises(sqlite3.ProgrammingError):
+            sql.get_timeseries("Site Outdoor Air Drybulb Temperature")
+
+        # With the handle released, the directory can be removed (the failing
+        # operation on Windows pre-fix).
+        shutil.rmtree(result_dir)
+        assert not result_dir.exists()
+
+    def test_close_is_idempotent(self, result: SimulationResult) -> None:
+        assert result.sql is not None
+        result.close()
+        result.close()  # must not raise
+
+    def test_close_with_no_sql_accessed(self, tmp_path: Path) -> None:
+        # close() before .sql was ever touched is a no-op.
+        _make_result(tmp_path).close()
+
+    def test_context_manager_closes_sql(self, result_dir: Path) -> None:
+        with SimulationResult(
+            run_dir=result_dir, success=True, exit_code=0, stdout="", stderr="", runtime_seconds=0.0
+        ) as result:
+            sql = result.sql
+            assert sql is not None
+        with pytest.raises(sqlite3.ProgrammingError):
+            sql.get_timeseries("Site Outdoor Air Drybulb Temperature")
+
+    def test_sql_reopens_after_close(self, result: SimulationResult) -> None:
+        first = result.sql
+        assert first is not None
+        result.close()
+        second = result.sql
+        assert second is not None
+        assert second is not first  # a fresh connection
+
+    def test_sqlresult_del_closes_connection(self, result_dir: Path) -> None:
+        sql = SQLResult(result_dir / "eplusout.sql")
+        assert not sql._closed
+        sql.__del__()
+        assert sql._closed
+
+
 class TestVariablesProperty:
     """Tests for SimulationResult.variables."""
 


### PR DESCRIPTION
## Summary

Fixes the Windows `PermissionError [WinError 32]: the process cannot access the file because it is being used by another process: ...\eplus.sql` that users hit when a simulation run directory (e.g. inside a `tempfile.TemporaryDirectory`) is deleted after reading SQL results.

## Root cause

`SimulationResult.sql` lazily opens a `sqlite3` connection against `eplus.sql` and caches it in `_cached_sql` for the result's lifetime — but `SimulationResult` had **no way to close it**: no `close()`, no context-manager protocol, and nothing ever called the existing `SQLResult.close()`.

- On POSIX, an open file handle doesn't block `unlink`, so this was invisible.
- On **Windows**, SQLite holds an exclusive OS lock on the open database, so `shutil.rmtree` / `TemporaryDirectory` cleanup fails once `result.sql` has been touched.

## Changes

- **`SimulationResult`**: add `close()` plus `__enter__`/`__exit__`. Closing releases the cached SQL connection and resets the cache, so `result.sql` reopens transparently on next access.
- **`SQLResult`**: harden `close()` (idempotent; unlinks the temp copy made for remote-fs reads) and add a `__del__` safety net that closes the connection on garbage collection.
- Remote-fs temp copies are now marked `_owns_file=True` so they're cleaned up on close.
- Docs: new "Releasing file handles" section in the `result-parsing` agent reference (+ snippet), re-baked bundle, and a CHANGELOG entry.

## Recommended usage

```python
with simulate(doc, weather, output_dir=run_dir) as result:
    ts = result.sql.get_timeseries(...)
# connection closed here -> run-dir / TemporaryDirectory cleanup succeeds
```

…or call `result.close()` in a `finally`.

## Testing

- New `TestClose` tests reproduce the scenario: after `close()`, querying raises `sqlite3.ProgrammingError` and `shutil.rmtree(run_dir)` succeeds. Also covers context-manager close, idempotency, lazy reopen, and `SQLResult.__del__`.
- Full simulation test suite: 774 passed, 1 skipped.
- Verified end-to-end against a real EnergyPlus 26.1.0 run inside a `TemporaryDirectory` (read 25 SQL reports, clean teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)